### PR TITLE
Include Bash-completion in cli-extras

### DIFF
--- a/targets/cli-extra
+++ b/targets/cli-extra
@@ -7,4 +7,4 @@ DESCRIPTION='Basic CLI tools such as wget and ssh.'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-apt-get -y install wget openssh-client
+apt-get -y install wget openssh-client bash-completion


### PR DESCRIPTION
Bash-completion clearly falls under 'near-essential CLI tools'

Also, my first official pull req so forgive me if I'm doing anything wrong!
