### PR TITLE
Fix for udev /run/udev in raring

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -265,7 +265,7 @@ bindmount /var/run/shill /var/host/shill
 ln -sf /dev/shm "`fixabslinks '/var/run/'`"
 
 # Add a /run/udev symlink for later versions of udev
-ln -sf /dev/.udev "`fixabslinks '/var/run/udev'`"
+ln -sfT /dev/.udev "`fixabslinks '/var/run'`/udev"
 
 # Bind-mount /media, specifically the removable directory
 destmedia="`fixabslinks '/var/host/media'`"


### PR DESCRIPTION
udev made the transition from using `/dev/.udev` to `/run/udev` for its runtime files - this interferes with Xorg's initial input device scan (which uses `/sys`, and then loads device information from `/run/udev`), but not with devices that are added or removed later (Xorg uses libudev-monitor for those).

I added a symlink from `/dev/.udev` to `/run/udev` that fixes the problem - Xorg can (once again) properly detect all input devices at startup.

This should fix #110.
Also appears to fix #112.
