### PR TITLE
Use echo -n to avoid param=-n from being swallowed.

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -349,7 +349,7 @@ else
         # Escape out the command
         cmd=''
         for param in "$@"; do
-            cmd="$cmd'`echo "$param" | sed "s/'/'\\\\\\''/g"`' "
+            cmd="$cmd'`echo -n "$param" | sed "s/'/'\\\\\\''/g"`' "
         done
         env -i TERM="$TERM" chroot "$CHROOT" su -c "$cmd" - "$USERNAME" \
             || ret=$?


### PR DESCRIPTION
I was trying to run a command with a command-line parameter of -n but it kept disappearing. Since echo can only have one option parameter, and doesn't recognize -- as end-of-options, it seems fine to preemptively pass -n.
