### PR TITLE
Fix unmount when a chroot name is a prefix of another.

### DIFF
--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -193,7 +193,7 @@ for NAME in "$@"; do
     fi
 
     while ! sed "s=\\\\040=//=g" /proc/mounts | cut -d' ' -f2 \
-              | grep -E "^$baseesc(/.*)?$" | sed 's=//= =g' | xargs --no-run-if-empty -d '
+              | grep "^$baseesc\\(/.*\\)\\?\$" | sed 's=//= =g' | xargs --no-run-if-empty -d '
 ' -n 50 umount 2>/dev/null; do
         if [ "$ntries" -eq "$TRIES" ]; then
             # Send signal to all processes running under the chroot


### PR DESCRIPTION
E.g. unmounting `precise` will also umount directories under `precisecore`, as grep matches any mount that starts with `/usr/local/chroots/precise` .
