### PR TITLE
Make enter-chroot elevate itself

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -3,6 +3,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# Rerun myself with elevated privileges if my beloved user forgot to do so...
+[[ `id -u` -ne 0 ]] && exec sudo bash $0 $*
+
 APPLICATION="${0##*/}"
 BACKGROUND=''
 BINDIR="`dirname "$0"`"
@@ -50,10 +53,6 @@ while getopts 'bc:k:n:u:x' f; do
 done
 shift "$((OPTIND-1))"
 
-# We need to run as root
-if [ ! "$USER" = root -a ! "$UID" = 0 ]; then
-    error 2 "$APPLICATION must be run as root."
-fi
 
 # We need a command if we specified to run in the background
 if [ -n "$BACKGROUND" -a $# = 0 ]; then


### PR DESCRIPTION
Enter-chroot pretty much always needs to be run with elevated privileges, and
it used to force the user to re-run it. Now enter-chroot will re-run itself
with sudo.
