### PR TITLE
Don't pull non-existent updates from sid, since this causes the chroot prep to fail.

### DIFF
--- a/targets/core
+++ b/targets/core
@@ -67,9 +67,13 @@ EOF
         cat > /etc/apt/sources.list <<EOF
 deb $MIRROR $RELEASE main contrib
 deb-src $MIRROR $RELEASE main contrib
+EOF
+        if [ "$RELEASE" != 'sid' ]; then
+            cat >> /etc/apt/sources.list <<EOF
 deb $MIRROR $RELEASE-updates main contrib
 deb-src $MIRROR $RELEASE-updates main contrib
 EOF
+        fi
     fi
 
     apt-get -y update


### PR DESCRIPTION
Trying to use crouton -r sid fails to complete because there are no apt updates for sid. 
