### PR TITLE
Give GNOME a diet - use --minimal flag

### DIFF
--- a/targets/gnome
+++ b/targets/gnome
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 REQUIRES='chromium gtk-extra'
-DESCRIPTION='Installs the GNOME desktop environment. (Approx. 600MB)'
+DESCRIPTION='Installs the GNOME desktop environment. (Approx. 400MB)'
 HOSTBIN='startgnome'
 CHROOTBIN='startgnome gnome-session-wrapper'
 . "${TARGETSDIR:="$PWD"}/common"
@@ -11,7 +11,7 @@ CHROOTBIN='startgnome gnome-session-wrapper'
 ### Append to prepare.sh:
 install --minimal evolution-data-server gnome-control-center \
         gnome-screensaver gnome-session gnome-session-fallback \
-        gnome-shell gnome-themes-standard nautilus
+        gnome-shell gnome-themes-standard gvfs-backends nautilus
 
 TIPS="$TIPS
 You can start GNOME via the startgnome host command: sudo startgnome


### PR DESCRIPTION
The GNOME target is pulling in too many packages by default, bloating chroots unnecessarily. Applying the `--minimal` flag will prevent unneeded packages from being installed with the default GNOME target.

Tested the flag on wheezy and raring - GNOME is completely functional with its new diet.

Refs #281
