### PR TITLE
Add shared home support to enter-chroot

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -26,6 +26,7 @@ Options:
     -k KEYFILE  Override the auto-detected encryption key location.
     -n NAME     Name of the chroot to enter. Default: first one found in CHROOTS
     -u USERNAME Username (or UID) to log into. Default: 1000 (the primary user)
+    -h HOME     Path to $HOME if you wish to share it across chroots.
     -x          Does not log in, but directly executes the command instead.
                 Note that the environment will be empty (sans TERM).
                 Specify -x a second time to run the $SETUPSCRIPT script."
@@ -34,7 +35,7 @@ Options:
 . "$BINDIR/../installer/functions"
 
 # Process arguments
-while getopts 'bc:k:n:u:x' f; do
+while getopts 'bc:k:n:u:xh:' f; do
     case "$f" in
     b) BACKGROUND='y';;
     c) CHROOTS="`readlink -f "$OPTARG"`";;
@@ -43,6 +44,7 @@ while getopts 'bc:k:n:u:x' f; do
     u) USERNAME="$OPTARG";;
     x) NOLOGIN="$((NOLOGIN+1))"
        [ "$NOLOGIN" -gt 2 ] && NOLOGIN=2;;
+    h) USERHOME="$OPTARG";;
     \?) error 2 "$USAGE";;
     esac
 done
@@ -321,6 +323,13 @@ if [ -d "$CHROOT/media" ] && ! mountpoint -q "$destmedia"; then
     mkdir -p "$destmedia"
     ln -sf "/var/host/media/removable" "$CHROOT/media/"
     mount --rbind /media "$destmedia"
+fi
+
+
+# If the user has specified a seperate $HOME (e.g. on their main system) then
+# Bind-mount it into place
+if [ -z "$NOLOGIN" -a -n "$CHROOTHOME" -a -d "$USERHOME" ]; then
+    bindmount "$USERHOME" "$CHROOTHOME/" exec
 fi
 
 # Bind-mount ~/Downloads if we're logged in as a user


### PR DESCRIPTION
By passing the -h option to enter-chroot you can now specify a
common location for /home/alex to be bind-mounted from. This
means you can have a common home across chroots which saves
effort in setting up all your dotfiles every time ;-).

Based on a post on the G+ Crouton community by Philip S.
