### PR TITLE
Change handling of USB persistence (fixes #288)

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -104,22 +104,12 @@ if [ -z "$CROUTON_NO_UNMOUNT" ]; then
     addtrap "sh -e '$BINDIR/unmount-chroot' -yc '$CHROOTS' '$NAME' || true"
 fi
 
-# If our root is on an external disk, we need to override powerd_suspend to not
-# disable USB device persistence, otherwise we will die on resume.
-# Because the system hardcodes the path to powerd_suspend, we have to completely
-# replace /usr/bin with a tmpfs that links to the original files.
-if [ ! "${CHROOT#/media}" = "$CHROOT" ] && ! mountpoint -q '/usr/bin'; then
-    newbin='/var/run/bin'
-    mkdir -p "$newbin"
-    if ! mountpoint -q "$newbin"; then
-        mount --bind -o ro /usr/bin "$newbin"
-    fi
-    mount -t tmpfs -o mode=755,uid=0,gid=0 tmpfs /usr/bin
-    ln -s "$newbin"/* /usr/bin/
-    pds='/usr/bin/powerd_suspend'
-    rm -f "$pds"
-    sed -e 's|do echo 0|do echo 1|' "$newbin/powerd_suspend" > "$pds"
-    chmod 755 "$pds"
+# If our root is on an external disk we need to ensure USB device persistence is
+# enabled otherwise we will lose the file-system after a suspend event.
+if [ ! "${CHROOT#/media}" = "$CHROOT" ]; then
+    for usbp in /sys/bus/usb/devices/*/power/persist; do
+        echo 1 > "$usbp"
+    done
 fi
 
 # Offer to run the setup script if it exists and yet we're logging in.

--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -276,17 +276,12 @@ for NAME in "$@"; do
     sync
 done
 
-# Remove /usr/bin override if it's no longer necessary (nothing important is
-# running with a root in removable media)
-if mountpoint -q /usr/bin && checkusage /media; then
-    newbin="`readlink '/usr/bin/env'`"
-    newbin="${newbin%/env}"
-    # Split the umount calls so if the first fails, the second won't happen.
-    if umount '/usr/bin' 2>/dev/null; then
-        # These may fail if you opened a new crosh. It doesn't hurt to leave it.
-        umount "$newbin" 2>/dev/null || true
-        rmdir "$newbin" 2>/dev/null || true
-    fi
+# Re-disable USB persistence (the Chromium OS default) if we no longer
+# have chroots running with a root in removable media
+if checkusage /media; then
+    for usbp in /sys/bus/usb/devices/*/power/persist; do
+        echo 0 > "$usbp"
+    done
 fi
 
 exit $ret


### PR DESCRIPTION
In the old way of doing things ChromeOS would turn off device
persistence to save a few milliseconds of suspend time. Crouton had to
jump though hoops to stop it doing this if the chroot was on a USB
device.

Since upstream merged commit: 0007a546853a529064772b1b96bd9164dece8c46
into power_manager.git and defaulted the kernel to have USB persistence
off all we now need to do is turn it on when we detect a chroot in
/media (where USB devices are mounted).

Arguably you could be smarter about which USB devices to enable but at
least by doing them all you ensure nothing breaks and it works.
