### PR TITLE
Pass -x and -v set options from main.sh to prepare.sh (useful for debugging).

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -406,11 +406,21 @@ fi
 # Ensure that /usr/local/bin and /etc/crouton exist
 mkdir -p "$CHROOT/usr/local/bin" "$CHROOT/etc/crouton"
 
+# If this script was called with '-x' or '-v', pass that to prepare.sh
+SETOPTIONS=""
+if set -o | grep -q '^xtrace *on$'; then
+    SETOPTIONS="-x"
+fi
+if set -o | grep -q '^verbose *on$'; then
+    SETOPTIONS="$SETOPTIONS -v"
+fi
+
 # Create the setup script inside the chroot
 echo 'Preparing chroot environment...' 1>&2
 VAREXPAND="s #ARCH $ARCH ;s #MIRROR $MIRROR ;"
 VAREXPAND="${VAREXPAND}s #DISTRO $DISTRO ;s #RELEASE $RELEASE ;"
 VAREXPAND="${VAREXPAND}s #PROXY $PROXY ;s #VERSION $VERSION ;"
+VAREXPAND="${VAREXPAND}s/#SETOPTIONS/$SETOPTIONS/;"
 installscript "$INSTALLERDIR/prepare.sh" "$CHROOT/prepare.sh" "$VAREXPAND"
 # Append the distro-specific prepare.sh
 cat "$DISTRODIR/prepare" >> "$CHROOT/prepare.sh"

--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Usage: prepare.sh arch mirror distro release proxy version
+# Usage: prepare.sh arch mirror distro release proxy version setoptions
 ARCH="${1:-"#ARCH"}"
 # MIRROR may contain variables (e.g., $repo): make sure we do not expand it
 MIRROR=${2:-'#MIRROR'}
@@ -11,6 +11,12 @@ DISTRO="${3:-"#DISTRO"}"
 RELEASE="${4:-"#RELEASE"}"
 PROXY="${5:-"#PROXY"}"
 VERSION="${6:-"#VERSION"}"
+SETOPTIONS="${7:-"#SETOPTIONS"}"
+
+# Additional set options: -x or -v can be added for debugging (-e is always on)
+if [ -n "$SETOPTIONS" ]; then
+    set $SETOPTIONS
+fi
 
 # We need all paths to do administrative things
 export PATH='/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'


### PR DESCRIPTION
I find this useful for debugging (instead of modifying `prepare.sh`'s first line manually, and reverting before a commit): you just call `sh -x -e installer/main.sh ...` and get traces not only in main.sh, but also in prepare.sh. It could be useful for bug reports as well.

It was a bit easier to implement before you added the `-xx` option to `enter-chroot` (it's a bit more "invasive" now).
