### PR TITLE
Allow user to use software center and/or update manager in the chroot

### DIFF
--- a/targets/unity
+++ b/targets/unity
@@ -13,7 +13,7 @@ CHROOTBIN='startunity gnome-session-wrapper'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-install unity unity-2d ubuntu-artwork gnome-session nautilus \
+install unity unity-2d ubuntu-artwork gnome-session nautilus ubuntu-desktop \
         ubuntu-settings,ubuntu~precise= -- network-manager brasero firefox
 
 TIPS="$TIPS


### PR DESCRIPTION
Without ubuntu-desktop installed, there's no Ubuntu Font and no way to install software, install updates, or upgrade to new releases without firing up a terminal window...
