### PR TITLE
Add unzip to gnome target

### DIFF
--- a/targets/gnome
+++ b/targets/gnome
@@ -11,7 +11,7 @@ CHROOTBIN='startgnome gnome-session-wrapper'
 ### Append to prepare.sh:
 install --minimal evolution-data-server gnome-control-center \
         gnome-screensaver gnome-session gnome-session-fallback \
-        gnome-shell gnome-themes-standard gvfs-backends nautilus
+        gnome-shell gnome-themes-standard gvfs-backends nautilus unzip
 
 TIPS="$TIPS
 You can start GNOME via the startgnome host command: sudo startgnome


### PR DESCRIPTION
GNOME shell extensions need `unzip` to be installed via the fancy web interface

Fixes #327
