### PR TITLE
croutonwheel: Fix issue when external mouse is connected.

### DIFF
--- a/chroot-bin/croutonwheel
+++ b/chroot-bin/croutonwheel
@@ -65,10 +65,10 @@ aura="`xwininfo -root -children | mawk '/aura_root/ {print $1}'`"
     trap "kill $! $xi 2>&- || true" INT TERM HUP 0
     wait
 } <&- | mawk -W interactive '
-    # Test if x is a non-zero real number (i.e. not nan, inf, or 0)
+    # Test if x is a non-zero real number (i.e. not "", nan, inf, or 0)
     # (x+0 != x+1) tests if the number is not nan or inf.
     function isnonzero(x) {
-        return (x+0 != x+1) && (x != 0)
+        return (x != "") && (x+0 != x+1) && (x != 0)
     }
 
     m {


### PR DESCRIPTION
There are fewer valuators with external mouse compared to trackpad: we need to check if the value is empty as well (and not just `nan`).

Simply moving the mouse was causing a flood of emulated wheel clicks that would end up with Xephyr using a lot of CPU time and a sluggish system, hard to recover...

Solves @vampirexhunter & @jnack95 problem in #326, but not the original issue (that was submitted before the new `croutonwheel` anyway).
