### PR TITLE
Fix cras build on R23 (2913.331.0, adhd branch release-R23-2913.B).

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -81,6 +81,7 @@ addtrap "rm -rf '$CRASBUILDTMP' 2>/dev/null"
     {
         echo '
             top_srcdir=".."
+            top_builddir=".."
             SBC_LIBS="'"`pkg-config --libs sbc`"'"
             SBC_CFLAGS="'"`pkg-config --cflags sbc`"'"
             DBUS_LIBS="'"`pkg-config --libs dbus-1`"'"


### PR DESCRIPTION
Well, that's a quick and easy one, so why not. It's obviously compile-tested only.

Fixes #374 & #377, but, really, these users should upgrade Chrome OS.
