### PR TITLE
compile: Build output to a temporary file, then use `/usr/bin/install` to install the file with correct permissions.

### DIFF
--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -187,7 +187,7 @@ compile() {
     local tmp="`mktemp crouton.XXXXXX --tmpdir=/tmp`"
     addtrap "rm -f '$tmp' 2>/dev/null"
     gcc -xc -Os - $linker -o "$tmp"
-    /usr/bin/install -sD "$tmp" "$out"
+    /usr/bin/install -sDT "$tmp" "$out"
 }
 
 


### PR DESCRIPTION
Something you suggested a while ago.

I removed the `if`, I'm not sure what your original intent was (but the install will fail anyway if `compile` returns 1, right?).
