### PR TITLE
Disable hung task timeout in installer and enter-chroot.

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -109,8 +109,7 @@ elif [ -n "$TARGET" ]; then
     fi
 fi
 
-# Prevent kernel panic due to hung task timeout when doing large I/O transfers
-# to slow devices.
+# Avoid kernel panics due to slow I/O
 disablehungtask
 
 # Make sure we always exit with echo on the tty.

--- a/installer/functions
+++ b/installer/functions
@@ -67,14 +67,11 @@ undotrap() {
     settrap "$TRAP"
 }
 
-# Do not panic on hung task timeout.
-# Large writes on the Samsung ARM Chromebook, especially to external devices
-# (SD card or USB stick) can cause a task to be stuck for longer than 120
-# seconds, which would cause a kernel panic (and an immediate reboot).
-# Instead of disabling the timeout altogether, we just make sure the kernel
-# does not panic (this is the default configuration of a vanilla kernel).
-# See http://code.google.com/p/chromium/issues/detail?id=260955 for details,
-# and why this may not be fixed upstream.
+# Large writes to slow devices (e.g. SD card or USB stick) can cause a task to
+# be stuck for longer than 120 seconds, which triggers a kernel panic (and an
+# immediate reboot). Instead of disabling the timeout altogether, we just make
+# sure the kernel does not panic (this is the default configuration of a vanilla
+# kernel). See crbug.com/260955 for details.
 disablehungtask() {
     echo 0 > /proc/sys/kernel/hung_task_panic
 }

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -144,10 +144,7 @@ if [ ! $# = 0 ]; then
 fi
 
 if [ "$USER" = root -o "$UID" = 0 ]; then
-    # If running as root, prevent kernel panic due to hung task timeout when
-    # doing large I/O transfers to slow devices. This is also done in
-    # enter-chroot, but we need to do it earlier to avoid the issue while
-    # restoring from tarball or bootstrapping.
+    # Avoid kernel panics due to slow I/O when restoring or bootstrapping
     disablehungtask
 fi
 


### PR DESCRIPTION
Large writes on the Samsung ARM Chromebook, especially to external devices
(SD card or USB stick) can cause a task to be stuck for longer than 120
seconds, which would cause a kernel panic (and an immediate reboot).

Instead of disabling the timeout altogether, we just make sure the kernel
does not panic by writing 0 to `/proc/sys/kernel/hung_task_panic` (this is
the default configuration of a vanilla kernel).

See http://code.google.com/p/chromium/issues/detail?id=260955 for details,
and why this may not be fixed upstream. Also fixes #319.
