### PR TITLE
Make sure enter/unmount-chroot work even if there is no USB devices at all (QEMU).

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -149,7 +149,9 @@ fi
 # enabled otherwise we will lose the file-system after a suspend event.
 if [ ! "${CHROOT#/media}" = "$CHROOT" ]; then
     for usbp in /sys/bus/usb/devices/*/power/persist; do
-        echo 1 > "$usbp"
+        if [ -e "$usbp" ]; then
+            echo 1 > "$usbp"
+        fi
     done
 fi
 

--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -281,7 +281,9 @@ done
 # have chroots running with a root in removable media
 if checkusage /media; then
     for usbp in /sys/bus/usb/devices/*/power/persist; do
-        echo 0 > "$usbp"
+        if [ -e "$usbp" ]; then
+            echo 0 > "$usbp"
+        fi
     done
 fi
 


### PR DESCRIPTION
I have that fancy and dirt-cheap "QEMU Chromiumbook", but it won't work with crouton because it doesn't have USB (I told you it was cheap...).
