### PR TITLE
Add `set -e` to all host scripts (#392).

### DIFF
--- a/build/wrapper.sh
+++ b/build/wrapper.sh
@@ -34,6 +34,8 @@
 # and then runs installer/main.sh with the parameters passed to it.
 # You can pass -x [directory] to extract the contents somewhere.
 
+set -e
+
 VERSION='git'
 
 # Minimum Chromium OS version is R28 stable

--- a/host-bin/edit-chroot
+++ b/host-bin/edit-chroot
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 BACKUP=''
 BINDIR="`dirname "\`readlink -f "$0"\`"`"

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 BACKGROUND=''
 BINDIR="`dirname "\`readlink -f "$0"\`"`"

--- a/host-bin/mount-chroot
+++ b/host-bin/mount-chroot
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 BINDIR="`dirname "\`readlink -f "$0"\`"`"
 CHROOTS="`readlink -f "$BINDIR/../chroots"`"

--- a/host-bin/startcinnamon
+++ b/host-bin/startcinnamon
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startcli
+++ b/host-bin/startcli
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/starte17
+++ b/host-bin/starte17
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startgnome
+++ b/host-bin/startgnome
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startkde
+++ b/host-bin/startkde
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startlxde
+++ b/host-bin/startlxde
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startunity
+++ b/host-bin/startunity
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startxbmc
+++ b/host-bin/startxbmc
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/startxfce4
+++ b/host-bin/startxfce4
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 
 USAGE="$APPLICATION [options]

--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 ALLCHROOTS=''
 BINDIR="`dirname "\`readlink -f "$0"\`"`"

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 APPLICATION="${0##*/}"
 SCRIPTDIR="${SCRIPTDIR:-"`dirname "$0"`/.."}"
 CHROOTBINDIR="$SCRIPTDIR/chroot-bin"


### PR DESCRIPTION
`-e` is critical for error handling in crouton: make sure the flag is set even if the user forgets to add it on the command line.
