### PR TITLE
Make sure compile works even if it is indented.

### DIFF
--- a/targets/common
+++ b/targets/common
@@ -84,7 +84,7 @@ elif [ ! "$TARGETS" = 'check' ]; then
             }
             next;
         }
-        ok && /^compile / {
+        ok && /^ *compile / {
             src = "'"${SRCDIR:-$TARGETSDIR/../src}"'/" $2 ".c";
         }
         src && $NF != substr("\\\\", 1, 1) {


### PR DESCRIPTION
When indented, `compile` does not get the source file piped in, and hangs forever.
