### PR TITLE
Map IDs for all groups referenced by Chromium OS udev rules.

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -356,7 +356,8 @@ fi
 # so that users have access to shared hardware, such as video and audio.
 gfile="$CHROOT/etc/group"
 if [ -f "$gfile" ]; then
-    for group in audio:hwaudio cras:audio video usb:plugdev; do
+    for group in audio:hwaudio cras:audio cdrom disk floppy i2c input lp \
+                 serial tape tty usb:plugdev uucp video; do
         hostgroup="${group%:*}"
         chrootgroup="${group#*:}"
         gid="`awk -F: '$1=="'"$hostgroup"'"{print $3; exit}' '/etc/group'`"


### PR DESCRIPTION
Added all groups used by udev rules in Chromium OS (`/lib/udev/rules.d/*`).

Fixes #473 (needs group `serial`).

Auto-tested in `2013-11-07_02-43-58_drinkcat_chroagh_add_groups_10` (`10-basic` only)
