### PR TITLE
Pick up default mirror from environment variables `CROUTON_MIRROR_<distro>[_<arch>]`.

### DIFF
--- a/installer/debian/defaults
+++ b/installer/debian/defaults
@@ -11,6 +11,6 @@ if [ -z "$ARCH" ]; then
 fi
 
 if [ -z "$MIRROR" ]; then
-    MIRROR='http://ftp.debian.org/debian/'
+    MIRROR="${CROUTON_MIRROR_debian:-http://ftp.debian.org/debian/}"
 fi
 

--- a/installer/ubuntu/defaults
+++ b/installer/ubuntu/defaults
@@ -12,9 +12,9 @@ fi
 
 if [ -z "$MIRROR" ]; then
     if [ "$ARCH" = 'amd64' -o "$ARCH" = 'i386' ]; then
-        MIRROR='http://archive.ubuntu.com/ubuntu/'
+        MIRROR="${CROUTON_MIRROR_ubuntu_x86:-http://archive.ubuntu.com/ubuntu/}"
     else
-        MIRROR='http://ports.ubuntu.com/ubuntu-ports/'
+        MIRROR="${CROUTON_MIRROR_ubuntu_arm:-http://ports.ubuntu.com/ubuntu-ports/}"
     fi
 fi
 


### PR DESCRIPTION
This is mainly useful in the context of automated testing, so these variables can be set to a local mirror in a `.bashrc` or something.

Can also be set by the user, but then `sudo -E` must be used to run crouton to make sure these variables get passed to the installer. So they'll probably never notice...

I looked for other ways of doing this in `test/run.sh`, but it would imply parsing parameters to crouton to detect which release is being installed, then detect the distribution from that, and finally checking that `-u` is not set (and possibly some other hacks I didn't think of). Doesn't look fun.
