### PR TITLE
tests/14-background: remove rc.local instead of making a backup copy of it

### DIFF
--- a/test/tests/14-background
+++ b/test/tests/14-background
@@ -33,13 +33,15 @@ echo "$s" | host enter-chroot -b -n "$RELEASE" cat | passes grep "$s" | log
 # Even with a failing rc.local it should work
 log 'Making rc.local fail'
 rclocal="$PREFIX/chroots/$RELEASE/etc/rc.local"
-mv -f "$rclocal" "$rclocal.bak"
 echo '#!/bin/sh -e
 exit 1' > "$rclocal"
 chmod a+rx "$rclocal"
 host enter-chroot -b -n "$RELEASE" true
 waitfinish
-mv -f "$rclocal.bak" "$rclocal"
+# Remove the failing rc.local: it should also work without rc.local
+rm -f "$rclocal"
+host enter-chroot -b -n "$RELEASE" true
+waitfinish
 
 # Even with a failing dbus-daemon it should work
 log 'Making dbus-daemon fail'


### PR DESCRIPTION
Arch doesn't ship with `/etc/rc.local`, so making a backup of that file makes the logic a little over complicated for our purpose.

Ubuntu/Debian default `/etc/rc.local` doesn't do anything anyway, so we can just remove it after the fail-test.
