### PR TITLE
jessie: Install xbindkeys directly from mirror.

### DIFF
--- a/targets/x11-common
+++ b/targets/x11-common
@@ -17,7 +17,11 @@ ln -sf croutonpowerd /usr/local/bin/gnome-screensaver-command
 ln -sf croutonpowerd /usr/local/bin/xscreensaver-command
 
 # Install xbindkeys for key shortcuts
-install --minimal xbindkeys
+if release -eq jessie; then
+    install_mirror_package 'xbindkeys' 'pool/main/x/xbindkeys' '1\.8\.5-.*'
+else
+    install --minimal xbindkeys
+fi
 
 # Add a blank Xauthority to all users' home directories
 touch /etc/skel/.Xauthority


### PR DESCRIPTION
Fixes #597.

I'll keep pushing upstream to get it back in jessie.
