### PR TITLE
Fix audio on master branch (build > 5512?)

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -26,6 +26,8 @@ if [ -z "$ADHD_HEAD" ]; then
     # Chrome OS version (e.g. 4100.86.0)
     CROS_VER="`sed -n 's/^CHROMEOS_RELEASE_VERSION=//p' /var/host/lsb-release`"
 
+    echo "Detecting CRAS branch (Chromium OS build $CROS_VER)..." 1>&2
+
     ADHD_HEAD="`awk '
         BEGIN {
             # Default to master if nothing else is found


### PR DESCRIPTION
Fix audio build on current ADHD master (sometimes after build 5511, not sure exactly which build).

Tested in `2014-02-23_14-09-14_drinkcat_chroagh_fix-audio-master-5512_-R_precise_30`. Note that `parrot-dev` failed, because its current build `5433.0.0` does not have a stabilize branch (dev channel is now `5500.4.0`, so it's a transient problem), and master is not compatible with `5433`.
