### PR TITLE
Revert "jessie: Install xbindkeys directly from mirror."

### DIFF
--- a/targets/x11-common
+++ b/targets/x11-common
@@ -17,11 +17,7 @@ ln -sf croutonpowerd /usr/local/bin/gnome-screensaver-command
 ln -sf croutonpowerd /usr/local/bin/xscreensaver-command
 
 # Install xbindkeys for key shortcuts
-if release -eq jessie; then
-    install_mirror_package 'xbindkeys' 'pool/main/x/xbindkeys' '1\.8\.5-.*'
-else
-    install --minimal xbindkeys
-fi
+install --minimal xbindkeys
 
 # Add a blank Xauthority to all users' home directories
 touch /etc/skel/.Xauthority


### PR DESCRIPTION
This reverts commit 19c75c0959aeaf6c3a0be6c1ea2f7b3584335c0b (that was a short-lived one...)

xbindkeys has been added back in jessie repository:
https://packages.debian.org/search?keywords=xbindkeys
