### PR TITLE
start*/enter-chroot: Make sure options with missing arguments are detected

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -56,7 +56,13 @@ chrootcmd() {
 }
 
 # Process arguments
+prevoptind=1
 while getopts 'bc:k:ln:t:u:x' f; do
+    # Disallow empty string as option argument
+    if [ "$((OPTIND-prevoptind))" = 2 -a -z "$OPTARG" ]; then
+        error 2 "$USAGE"
+    fi
+    prevoptind="$OPTIND"
     case "$f" in
     b) BACKGROUND='y';;
     c) CHROOTS="`readlink -f "$OPTARG"`";;
@@ -71,6 +77,12 @@ while getopts 'bc:k:ln:t:u:x' f; do
     esac
 done
 shift "$((OPTIND-1))"
+
+# Shift away empty string as first argument (used in start* scripts to mark
+# the end of user-specified parameters)
+if [ "$#" -ge 1 -a -z "$1" ]; then
+    shift
+fi
 
 # We need to run as root
 if [ ! "$USER" = root -a ! "$UID" = 0 ]; then

--- a/host-bin/startcinnamon
+++ b/host-bin/startcinnamon
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t cinnamon "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t cinnamon "$@" "" \
     exec startcinnamon

--- a/host-bin/startcli
+++ b/host-bin/startcli
@@ -15,5 +15,5 @@ By default, it will log into the primary user on the first chroot found.
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
 export TERM='linux'
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t cli-extra -l "$@"\
-    openvt -vws --
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t cli-extra -l \
+    "$@" "" openvt -vws --

--- a/host-bin/starte17
+++ b/host-bin/starte17
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t e17 "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t e17 "$@" "" \
     exec xinit /usr/bin/enlightenment_start

--- a/host-bin/startgnome
+++ b/host-bin/startgnome
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t gnome "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t gnome "$@" "" \
     exec startgnome

--- a/host-bin/startkde
+++ b/host-bin/startkde
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t kde "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t kde "$@" "" \
     exec xinit /usr/bin/startkde

--- a/host-bin/startlxde
+++ b/host-bin/startlxde
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t lxde "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t lxde "$@" "" \
     exec xinit /usr/bin/startlxde

--- a/host-bin/startunity
+++ b/host-bin/startunity
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t unity "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t unity "$@" "" \
     exec startunity

--- a/host-bin/startxbmc
+++ b/host-bin/startxbmc
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t xbmc "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t xbmc "$@" "" \
     exec xinit /usr/bin/xbmc

--- a/host-bin/startxfce4
+++ b/host-bin/startxfce4
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t xfce "$@" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t xfce "$@" "" \
     exec startxfce4


### PR DESCRIPTION
Mark the end of user specified parameters with `""`.

Makes sure commands like `sudo startcli -u` fail instead of outputing confusing messages like `user exec not found`).

Tested in `2014-03-03_13-05-54_drinkcat_chroagh_fix-startXX-arg_-R_precise_1`.
## 

For reference, there is a neater way to detect empty arguments:

```
if [ -z "$OPTARG" -a "${OPTARG-unset}" != "unset" ]; then
    error 2 "$USAGE"
fi
```

but `dash` is not POSIX-compliant in this case, and does not unset `OPTARG`...
