### PR TITLE
Support `+` tag on release list; drop support for raring.

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -156,7 +156,7 @@ if [ "$RELEASE" = 'list' -o "$RELEASE" = 'help' ]; then
             echo "$accum" 1>&2
         fi
     done
-    echo 'Releases marked with * or + are unsupported, but may work with some effort.' 1>&2
+    echo 'Releases marked with * are unsupported, but may work with some effort.' 1>&2
     exit 2
 fi
 
@@ -435,16 +435,13 @@ releaseline="`grep "^$RELEASE[^a-z]*$" "$DISTRODIR/releases" || true`"
 if [ "${releaseline%"*"}" != "$releaseline" ]; then
     echo "WARNING: $RELEASE is an unsupported release.
 You will likely run into issues, but things may work with some effort." 1>&2
+
     if [ -z "$UPDATE" ]; then
         echo "Press Ctrl-C to abort; installation will continue in 5 seconds." 1>&2
-    fi
-    sleep 5
-elif [ "${releaseline%"+"}" != "$releaseline" ]; then
-    echo "WARNING: $RELEASE is not supported anymore.
-Things will probably work, but you are advised to upgrade to a more recent
-release (see http://goo.gl/Z5LGVD for instructions)." 1>&2
-    if [ -z "$UPDATE" ]; then
-        echo "Press Ctrl-C to abort; installation will continue in 5 seconds." 1>&2
+    else
+        echo "\
+If this is a surprise to you, $RELEASE has probably reached end of life.
+Refer to http://goo.gl/Z5LGVD for upgrade instructions." 1>&2
     fi
     sleep 5
 fi

--- a/installer/ubuntu/releases
+++ b/installer/ubuntu/releases
@@ -15,6 +15,6 @@ natty*
 oneiric*
 precise
 quantal
-raring+
+raring*
 saucy
 trusty*

--- a/test/run.sh
+++ b/test/run.sh
@@ -19,7 +19,7 @@ set -e
 APPLICATION="${0##*/}"
 SCRIPTDIR="`readlink -f "\`dirname "$0"\`/.."`"
 # List of all supported (non-*'d) releases
-SUPPORTED_RELEASES="`awk '/[^*]$/ { sub(/[^a-z]*$/, "", $1); printf $1 " " }' \
+SUPPORTED_RELEASES="`awk '/[^*]$/ { printf $1 " " }' \
                          "$SCRIPTDIR/installer/"*"/releases"`"
 SUPPORTED_RELEASES="${SUPPORTED_RELEASES%" "}"
 # System info


### PR DESCRIPTION
`+` indicates that the release used to be supported, and encourages the user to upgrade. Auto-testing is still
performed on the release.
After a few months, the release should be switched to unsupported (`*`).

raring upstream support was dropped on 27 January 2014 (see https://wiki.ubuntu.com/Releases)

Tested in `2014-03-03_13-58-46_drinkcat_chroagh_drop-raring-support_1`.
