### PR TITLE
Test i386 chroots on x86-64 systems

### DIFF
--- a/installer/debian/defaults
+++ b/installer/debian/defaults
@@ -11,7 +11,7 @@ if [ -z "$ARCH" ]; then
 fi
 
 case "$ARCH" in
-i?86) ARCH="i386";;
+x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
 arm*) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;

--- a/installer/kali/defaults
+++ b/installer/kali/defaults
@@ -11,7 +11,7 @@ if [ -z "$ARCH" ]; then
 fi
 
 case "$ARCH" in
-i?86) ARCH="i386";;
+x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
 arm*) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;

--- a/installer/ubuntu/defaults
+++ b/installer/ubuntu/defaults
@@ -11,7 +11,7 @@ if [ -z "$ARCH" ]; then
 fi
 
 case "$ARCH" in
-i?86) ARCH="i386";;
+x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
 arm*) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;

--- a/test/tests/11-32-on-64
+++ b/test/tests/11-32-on-64
@@ -6,7 +6,7 @@
 # All supported releases should be able to create an i686 chroot on x86-64
 if [ "`uname -m`" = "x86_64" ]; then
     for release in $SUPPORTED_RELEASES; do
-        crouton -a i686 -r "$release" -t core
+        crouton -a x86 -r "$release" -t core
         host enter-chroot -n "$release" true
         host delete-chroot -y "$release"
     done


### PR DESCRIPTION
This should work (and, actually, it does, `2014-03-05_15-27-29_drinkcat_chroagh_i386-test_1`). It was broken on Arch, so I created this test.

Also, I modified `ARCH` handling in defaults scripts, so that we can specify i386/i686 and still get x86 chroot, amd64/x86_64 and get x86-64 chroot, and arm\* for arm. This is not needed for the current distros as they all use `i386`/`amd64`/`armhf`, but Arch uses `i686`/`x86-64`/`arm7h`. Having this flexibility allows us to have a common test for all distros (otherwise we would need kludgy ifs), and we can detect invalid architectures as a bonus.

This introduces a bit of code duplication (but, arguably, it was already there in the `sed` line...), not sure if it's worth doing something about it...
