### PR TITLE
crouton in a separate partition

### DIFF
--- a/host-bin/edit-chroot
+++ b/host-bin/edit-chroot
@@ -10,6 +10,8 @@ ALLCHROOTS=''
 BACKUP=''
 BINDIR="`dirname "\`readlink -f "$0"\`"`"
 CHROOTS="`readlink -m "$BINDIR/../chroots"`"
+CHROOTSSET=''
+MOUNTPOINT='/var/crouton'
 DELETE=''
 ENCRYPT=''
 KEYFILE=''
@@ -68,7 +70,7 @@ while getopts 'abc:def:k:lm:ry' f; do
     case "$f" in
     a) ALLCHROOTS='y';;
     b) BACKUP='y';;
-    c) CHROOTS="`readlink -m "$OPTARG"`";;
+    c) CHROOTS="`readlink -m "$OPTARG"`"; CHROOTSSET='y';;
     d) DELETE='y';;
     e) ENCRYPT='y';;
     f) TARBALL="$OPTARG";;
@@ -144,6 +146,13 @@ fi
 # We need to run as root
 if [ ! "$USER" = root -a ! "$UID" = 0 ]; then
     error 2 "$APPLICATION must be run as root."
+fi
+
+# Try to mount the crouton partition if it exists, CHROOTS has not been set
+# manually, and this script base directory is /usr/local/bin.
+if [ -z "$CHROOTSSET" -a "$BINDIR" = "/usr/local/bin" ] && \
+        mountcrouton "$MOUNTPOINT"; then
+    CHROOTS="$MOUNTPOINT/chroots"
 fi
 
 # If we're restoring and specified a tarball and no name, detect the name.

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -9,6 +9,8 @@ APPLICATION="${0##*/}"
 BACKGROUND=''
 BINDIR="`dirname "\`readlink -f "$0"\`"`"
 CHROOTS="`readlink -m "$BINDIR/../chroots"`"
+CHROOTSSET=''
+MOUNTPOINT='/var/crouton'
 KEYFILE=''
 LOGIN=''
 NAME=''
@@ -65,7 +67,7 @@ while getopts 'bc:k:ln:t:u:x' f; do
     prevoptind="$OPTIND"
     case "$f" in
     b) BACKGROUND='y';;
-    c) CHROOTS="`readlink -m "$OPTARG"`";;
+    c) CHROOTS="`readlink -m "$OPTARG"`"; CHROOTSSET='y';;
     k) KEYFILE="$OPTARG";;
     l) LOGIN='y';;
     n) NAME="$OPTARG";;
@@ -103,6 +105,13 @@ if [ "$NOLOGIN" = 2 ]; then
         error 2 "Cannot run the setup script in the background."
     fi
     set -- "$SETUPSCRIPT"
+fi
+
+# Try to mount the crouton partition if it exists, CHROOTS has not been set
+# manually, and this script base directory is /usr/local/bin.
+if [ -z "$CHROOTSSET" -a "$BINDIR" = "/usr/local/bin" ] && \
+        mountcrouton "$MOUNTPOINT"; then
+    CHROOTS="$MOUNTPOINT/chroots"
 fi
 
 # Select the first chroot available if one hasn't been specified

--- a/host-bin/mount-chroot
+++ b/host-bin/mount-chroot
@@ -8,6 +8,8 @@ set -e
 APPLICATION="${0##*/}"
 BINDIR="`dirname "\`readlink -f "$0"\`"`"
 CHROOTS="`readlink -m "$BINDIR/../chroots"`"
+CHROOTSSET=''
+MOUNTPOINT='/var/crouton'
 CREATE=''
 ENCRYPT=''
 KEYFILE=''
@@ -35,7 +37,7 @@ Options:
 # Process arguments
 while getopts 'c:ek:np' f; do
     case "$f" in
-    c) CHROOTS="`readlink -m "$OPTARG"`";;
+    c) CHROOTS="`readlink -m "$OPTARG"`"; CHROOTSSET='y';;
     e) ENCRYPT="$((ENCRYPT+1))";;
     k) KEYFILE="$OPTARG";;
     n) CREATE='y';;
@@ -53,6 +55,13 @@ fi
 # We need to run as root
 if [ ! "$USER" = root -a ! "$UID" = 0 ]; then
     error 2 "$APPLICATION must be run as root."
+fi
+
+# Try to mount the crouton partition if it exists, CHROOTS has not been set
+# manually, and this script base directory is /usr/local/bin.
+if [ -z "$CHROOTSSET" -a "$BINDIR" = "/usr/local/bin" ] && \
+        mountcrouton "$MOUNTPOINT"; then
+    CHROOTS="$MOUNTPOINT/chroots"
 fi
 
 # Make sure we always exit with echo on the tty.

--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -9,6 +9,8 @@ APPLICATION="${0##*/}"
 ALLCHROOTS=''
 BINDIR="`dirname "\`readlink -f "$0"\`"`"
 CHROOTS="`readlink -m "$BINDIR/../chroots"`"
+CHROOTSSET=''
+MOUNTPOINT='/var/crouton'
 EXCLUDEROOT=''
 FORCE=''
 PRINT=''
@@ -38,19 +40,14 @@ Options:
     -y          Signal any remaining processes without confirmation.
                 Automatically escalates from SIGTERM to SIGKILL."
 
-# Function to exit with exit code $1, spitting out message $@ to stderr
-error() {
-    local ecode="$1"
-    shift
-    echo "$*" 1>&2
-    exit "$ecode"
-}
+# Common functions
+. "$BINDIR/../installer/functions"
 
 # Process arguments
 while getopts 'ac:fkpt:xy' f; do
     case "$f" in
     a) ALLCHROOTS='y';;
-    c) CHROOTS="`readlink -m "$OPTARG"`";;
+    c) CHROOTS="`readlink -m "$OPTARG"`"; CHROOTSSET='y';;
     f) FORCE='y';;
     k) SIGNAL="KILL";;
     p) PRINT='y';;
@@ -77,6 +74,16 @@ fi
 # We need to run as root
 if [ ! "$USER" = root -a ! "$UID" = 0 ]; then
     error 2 "$APPLICATION must be run as root."
+fi
+
+# Try to mount the crouton partition if it exists, CHROOTS has not been set
+# manually, and this script base directory is /usr/local/bin.
+# This may not appear to be necessary in unmount-chroot, but mountcrouton both
+# detects and mounts the partition. We only really need the detection part here,
+# but mounting does not hurt (the partition most likely already is mounted).
+if [ -z "$CHROOTSSET" -a "$BINDIR" = "/usr/local/bin" ] && \
+        mountcrouton "$MOUNTPOINT"; then
+    CHROOTS="$MOUNTPOINT/chroots"
 fi
 
 # Check if a chroot is running with this directory. We detect the

--- a/installer/functions
+++ b/installer/functions
@@ -152,3 +152,27 @@ validate_name() {
     fi
     return 0
 }
+
+# Find the root device
+# Sets:
+#  - $ROOTDEVICE as the root device (e.g. /dev/sda or /dev/mmcblk0)
+#  - $ROOTDEVICEPREFIX as a prefix for partitions (/dev/sda, /dev/mmcblk0p)
+findrootdevice() {
+    ROOTDEVICE="`rootdev -d -s`"
+
+    if [ -z "$ROOTDEVICE" ]; then
+        error 1 "Cannot find root device."
+    fi
+
+    if [ ! -b "$ROOTDEVICE" ]; then
+        error 1 "$ROOTDEVICE is not a block device."
+    fi
+
+    # If $ROOTDEVICE ends with a number (e.g. mmcblk0), partitions are named
+    # ${ROOTDEVICE}pX (e.g. mmcblk0p1). If not (e.g. sda), they are named
+    # ${ROOTDEVICE}X (e.g. sda1).
+    ROOTDEVICEPREFIX="$ROOTDEVICE"
+    if [ "${ROOTDEVICE%[0-9]}" != "$ROOTDEVICE" ]; then
+        ROOTDEVICEPREFIX="${ROOTDEVICE}p"
+    fi
+}

--- a/installer/functions
+++ b/installer/functions
@@ -176,3 +176,30 @@ findrootdevice() {
         ROOTDEVICEPREFIX="${ROOTDEVICE}p"
     fi
 }
+
+# Try to mount the CROUTON partition, if it exists, on $MOUNTPOINT.
+mountcrouton() {
+    if [ -z "$ROOTDEVICE" ]; then
+        findrootdevice
+    fi
+
+    local croutonpart="`cgpt find -n -l CROUTON "$ROOTDEVICE"`"
+    if [ -z "$croutonpart" ]; then
+        return 1
+    fi
+
+    # Check if crouton is mounted already
+    if grep -q "^${ROOTDEVICEPREFIX}$croutonpart " /proc/mounts; then
+        # If mounted, it must be mounted to $mountpoint
+
+        if ! grep -q "^${ROOTDEVICEPREFIX}$croutonpart $MOUNTPOINT " \
+                                                        /proc/mounts; then
+            error 1 "Error: CROUTON partition is not mounted on $MOUNTPOINT."
+        fi
+    else
+        mkdir -p "$MOUNTPOINT" || error 1 "Cannot create $MOUNTPOINT."
+        mount "${ROOTDEVICEPREFIX}$croutonpart" "$MOUNTPOINT" || \
+            error 1 "Cannot mount $MOUNTPOINT"
+    fi
+    return 0
+}

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -41,6 +41,7 @@ UPDATEIGNOREEXISTING=''
 USAGE="$APPLICATION [options] -t targets
 $APPLICATION [options] -f backup_tarball
 $APPLICATION [options] -d -f bootstrap_tarball
+$APPLICATION -S [partition_options]
 
 Constructs a chroot for running a more standard userspace alongside Chromium OS.
 
@@ -50,6 +51,11 @@ the chroot is restored and relevant scripts installed.
 If run with -d, a bootstrap tarball is created to speed up chroot creation in
 the future. You can use bootstrap tarballs generated this way by passing them
 to -f the next time you create a chroot with the same architecture and release.
+
+If run with -S, a separate partition is created for crouton, immune from
+accidental wiping when switching back and forth between developer/normal mode,
+as well as powerwashes.
+Run $APPLICATION -S -h for additional help.
 
 $APPLICATION must be run as root unless -d is specified AND fakeroot is
 installed AND /tmp is mounted exec and dev.
@@ -106,6 +112,14 @@ secure as the passphrases you assign to them."
 #   -U          Same as -u, but does not reinstall existing targets.
 #               Targets specified with -t will be installed, but not recorded
 #               for future updates.
+
+# Pass parameters to mkpart.sh
+if [ "$1" = "-S" ]; then
+    shift
+    APPLICATION="$APPLICATION -S"
+    . "$SCRIPTDIR/installer/mkpart.sh"
+    exit 0
+fi
 
 # Common functions
 . "$SCRIPTDIR/installer/functions"

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-# Copyright (c) 2014 The Chromium OS Authors. All rights reserved.
+# Copyright (c) 2014 The crouton Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -317,15 +317,16 @@ fi
         chvt $LOGVT
         echo "$*" 1>&2
         echo "Press enter to reboot..."
+        sync
+        ( sleep 30; reboot ) &
         read line
         settrap ""
-        sync
         reboot
         exit "$ecode" # unreachable
     }
 
     addtrap "chvt $LOGVT; echo 'Something went wrong, press enter to reboot.';\
-             read line; echo 'Syncing...'; sync; echo 'Rebooting...'; reboot"
+             sync; (sleep 30; reboot) & read line; echo 'Rebooting...'; reboot"
 
     # Make sure screen does not blank out (setterm does not work in this
     # context: send control sequence instead)
@@ -466,10 +467,11 @@ fi
     cgpt show "$ROOTDEVICE" -i 1
     cgpt show "$ROOTDEVICE" -i "$CROUTONPARTNUMBER"
 
-    echo "Success! Press enter to reboot.."
+    echo "Success! Press enter to reboot..."
+    sync
+    ( sleep 30; reboot ) &
     read line
     settrap ""
-    sync
     reboot
 ) >"/dev/tty$LOGVT" 2>&1 <"/dev/tty$LOGVT" &
 

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -162,7 +162,7 @@ if [ -n "$DELETE" ]; then
 WARNING: Removing '$name' partition: ALL DATA ON THAT PARTITION WILL BE LOST.
 
 Type 'delete' if you are sure that you want to do that: "
-    read line
+    read -r line
     if [ "$line" != "delete" ]; then
         error 2 "Aborting..."
     fi
@@ -177,7 +177,7 @@ Using both ChrUbuntu and crouton partition is not recommended, especially if
 your total storage space is only 16GB, as the space for each system (Chromium OS
 stateful partition, crouton and ChrUbuntu) will be very limited.
 Do you still want to continue? [y/N] " 1>&2
-        read response
+        read -r response
         if [ "${response#[Yy]}" = "$response" ]; then
             exit 1
         fi
@@ -199,7 +199,7 @@ Do you still want to continue? [y/N] " 1>&2
 It is recommended that you follow the migration guide to transfer existing
 chroots to the new partition.
 Do you still want to continue? [y/N] " 1>&2
-        read response
+        read -r response
         if [ "${response#[Yy]}" = "$response" ]; then
             exit 1
         fi
@@ -265,7 +265,7 @@ crouton partition (-c)."
     echo "----"
 
     echo -n "Type 'yes' if you are you satisfied with these new sizes: "
-    read line
+    read -r line
     if [ "$line" != "yes" ]; then
         error 2 "Aborting..."
     fi
@@ -319,14 +319,15 @@ fi
         echo "Press enter to reboot..."
         sync
         ( sleep 30; reboot ) &
-        read line
+        read -r line
         settrap ""
         reboot
         exit "$ecode" # unreachable
     }
 
-    addtrap "chvt $LOGVT; echo 'Something went wrong, press enter to reboot.';\
-             sync; (sleep 30; reboot) & read line; echo 'Rebooting...'; reboot"
+    addtrap "chvt $LOGVT; echo 'Something went wrong, press enter to reboot.'; \
+             sync; ( sleep 30; reboot ) & read -r line; \
+             echo 'Rebooting...'; reboot"
 
     # Make sure screen does not blank out (setterm does not work in this
     # context: send control sequence instead)
@@ -423,7 +424,7 @@ fi
         echo "Services were stopped, and stateful partition is unmounted."
         echo "Press enter to switch back to VT2 (this is VT$LOGVT)."
         echo "Then login as root, and type reboot when you are done."
-        read line
+        read -r line
         sync
         chvt 2
         settrap ""
@@ -470,7 +471,7 @@ fi
     echo "Success! Press enter to reboot..."
     sync
     ( sleep 30; reboot ) &
-    read line
+    read -r line
     settrap ""
     reboot
 ) >"/dev/tty$LOGVT" 2>&1 <"/dev/tty$LOGVT" &

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -1,0 +1,450 @@
+#!/bin/sh -e
+# Copyright (c) 2014 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+if [ -z "$APPLICATION" -o -z "$PREFIX" ]; then
+    echo "Please do not call mkpart.sh directly: use main.sh -S." 1>&2
+    exit 2
+fi
+
+# Partition number to use
+CROUTONPARTNUMBER=13
+CROUTONPARTNUMBERSET=''
+# Minimum stateful partition size in MB
+MINIMUMSTATEFULSIZE=1500
+# Give at least 10%, and 200 MB, headroom in the current stateful partition
+MINIMUMSTATEFULMARGINPERCENT=10
+MINIMUMSTATEFULMARGINABS=200
+# Minimum crouton partition size in MB
+MINIMUMCROUTONSIZE=500
+# Stateful partition size
+STATEFULSIZE=2500
+STATEFULSIZESET=''
+# Crouton partition size
+CROUTONSIZE=''
+# Which VT to switch to
+LOGVT='9'
+NOCREATE=''
+DELETE=''
+
+USAGE="$APPLICATION [-s size|-c size|-d|-x] [-i number]
+
+Create a separate partition for crouton, immune from accidental wiping when
+switching back and forth to developer/normal mode.
+
+This script needs to log the user out, and reboot the system. Make sure no
+unsaved document/form is left unsaved.
+
+Under normal circumstances, the stateful partition will not be damaged.
+However, it is recommended to backup data as required (Downloads folder,
+existing chroots in /usr/local).
+
+$APPLICATION must be run as root.
+
+It is highly recommended to run this from a crosh shell (Ctrl+Alt+T), not VT2.
+
+Basic options:
+    -s size     Set the size in megabytes of the stateful partition, the rest
+                being allocated to crouton.
+                Default: $STATEFULSIZE MB
+                Minimum allowed size: $MINIMUMSTATEFULSIZE MB
+    -c size     Set the size in megabytes of the crouton partition.
+    -d          Delete a partition, and reset the stateful partition to its
+                maximum size. The partition to remove is autodetected using its
+                label (CROUTON), but it can be specified using '-i number'.
+                WARNING: This wipes the content of the crouton partition.
+
+Options for power users only:
+    -i number   The partition number to use for crouton. This script will fail
+                if the partition exists and is larger than a single sector.
+                Default: $CROUTONPARTNUMBER
+    -x          Do not create the new partition: only switch off all services,
+                switch to VT2, so that the partition layout can be edited
+                manually.
+"
+
+# Common functions
+. "$SCRIPTDIR/installer/functions"
+
+# Process arguments
+while getopts 'c:dhi:s:x' f; do
+    case "$f" in
+    c) CROUTONSIZE="$OPTARG";;
+    d) DELETE='y';;
+    h) error 2 "$USAGE";;
+    i) CROUTONPARTNUMBER="$OPTARG"; CROUTONPARTNUMBERSET='y';;
+    s) STATEFULSIZE="$OPTARG"; STATEFULSIZESET='y';;
+    x) NOCREATE='y';;
+    \?) error 2 "$USAGE";;
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ ! "$USER" = root -a ! "$UID" = 0 ]; then
+    error 2 "$APPLICATION must be run as root."
+fi
+
+test="${STATEFULSIZESET}${CROUTONSIZE:+y}${DELETE}${NOCREATE}"
+if [ "${#test}" -gt 1 ]; then
+    error 2 "Only one of -c, -d, -s and -x can be set.
+$USAGE"
+fi
+
+if ! [ "$CROUTONPARTNUMBER" -gt 0 ] 2>/dev/null \
+        || [ "$CROUTONPARTNUMBER" -gt 128 ]; then
+    error 2 "Partition number $CROUTONPARTNUMBER is not valid."
+fi
+
+if ! [ "$STATEFULSIZE" -gt 0 ] 2>/dev/null; then
+    error 2 "Partition size $STATEFULSIZE is not valid."
+fi
+
+if [ -n "$CROUTONSIZE" ] && ! [ "$CROUTONSIZE" -gt 0 ] 2>/dev/null; then
+    error 2 "Partition size $CROUTONSIZE is not valid."
+fi
+
+# Avoid kernel panics due to slow I/O
+disablehungtask
+
+# Set ROOTDEVICE
+findrootdevice
+
+# Restore stateful partition to its original size
+if [ -n "$DELETE" ]; then
+    if [ -z "$CROUTONPARTNUMBERSET" ]; then
+        CROUTONPARTNUMBER="`cgpt find -n -l CROUTON "$ROOTDEVICE" || true`"
+
+        if [ -z "$CROUTONPARTNUMBER" ]; then
+            error 1 "Cannot find CROUTON partition."
+        fi
+    fi
+
+    name="`cgpt show -i "$CROUTONPARTNUMBER" -l "$ROOTDEVICE"`"
+    name=${name:-unknown}
+
+    # Unit: sectors (512 bytes)
+    statestart="`cgpt show -i 1 -b "$ROOTDEVICE"`"
+    statesize="`cgpt show -i 1 -s "$ROOTDEVICE"`"
+    croutonstart="`cgpt show -i "$CROUTONPARTNUMBER" -b "$ROOTDEVICE"`"
+    croutonsize="`cgpt show -i "$CROUTONPARTNUMBER" -s "$ROOTDEVICE"`"
+    newstatesize="$((statesize+croutonsize))"
+
+    echo "Stateful partition:"
+    cgpt show -i 1 "$ROOTDEVICE"
+    echo "'$name' partition:"
+    cgpt show -i "$CROUTONPARTNUMBER" "$ROOTDEVICE"
+
+    if [ "$((statestart+statesize))" -ne "$croutonstart" ]; then
+        error 1 "Error: stateful and '$name' partitions are not contiguous."
+    fi
+
+    echo -n "
+WARNING: Removing '$name' partition: ALL DATA ON THAT PARTITION WILL BE LOST.
+
+Type 'delete' if you are sure that you want to do that: "
+    read line
+    if [ "$line" != "delete" ]; then
+        error 2 "Aborting..."
+    fi
+
+    # This could be done without reboot, as resize2fs can be done online.
+    # However, Chromium OS cannot re-read the partition table without reboot.
+elif [ -z "$NOCREATE" ]; then
+    rootc="`cgpt find -n -l ROOT-C "$ROOTDEVICE"`"
+    if [ "`cgpt show -i "$rootc" -s "$ROOTDEVICE"`" -gt 1 ]; then
+        error 1 "ROOT-C is not empty (did you install ChrUbuntu?)."
+    fi
+
+    if [ "`cgpt show -i "$CROUTONPARTNUMBER" -s "$ROOTDEVICE"`" -gt 1 ]; then
+        echo  "Partition $CROUTONPARTNUMBER already exists:" 1>&2
+        cgpt show -i "$CROUTONPARTNUMBER" "$ROOTDEVICE"
+        exit 1
+    fi
+
+    if cgpt find -n -l CROUTON "$ROOTDEVICE" > /dev/null; then
+        error 1 "CROUTON partition already exists."
+    fi
+
+    if [ -n "`find $PREFIX/chroots/* \
+                        -type d -maxdepth 0 2>/dev/null || true`" ]; then
+        echo -n "$PREFIX/chroots is not empty.
+It is recommended that you follow the migration guide to transfer existing
+chroots to the new partition.
+Do you still want to continue? [y/N] " 1>&2
+        read response
+        if [ "${response#[Yy]}" = "$response" ]; then
+            exit 1
+        fi
+    fi
+
+    # All GPT sizes/offsets are expressed in sectors (512 bytes)
+    statestart="`cgpt show -i 1 -b "$ROOTDEVICE"`"
+    statesize="`cgpt show -i 1 -s "$ROOTDEVICE"`"
+
+    if [ -n "$CROUTONSIZE" ]; then
+        STATEFULSIZE="$((statesize/(1024*2)-CROUTONSIZE))"
+    fi
+
+    # Make sure the stateful partition can be resized to the requested size
+    # Unit: KiB
+    statefulallocated="`df -P -k ${ROOTDEVICEPREFIX}1 \
+                            | awk 'x{print $3;exit} {x=1}'`"
+
+    if ! [ "$statefulallocated" -gt 0 ] 2>/dev/null; then
+        error 2 "Cannot obtain free space on stateful partition."
+    fi
+
+    # Unit: MiB
+    statefulsafe=$(((statefulallocated+\
+                     statefulallocated*MINIMUMSTATEFULMARGINPERCENT/100)/1024))
+    statefulsafe2=$((statefulallocated/1024+MINIMUMSTATEFULMARGINABS))
+    if [ "$MINIMUMSTATEFULSIZE" -gt "$statefulsafe" ]; then
+        statefulsafe="$MINIMUMSTATEFULSIZE"
+    fi
+    if [ "$statefulsafe2" -gt "$statefulsafe" ]; then
+        statefulsafe="$statefulsafe2"
+    fi
+
+    if [ "$STATEFULSIZE" -lt "$statefulsafe" ]; then
+        error 1 \
+"Cannot shrink the stateful partition under $statefulsafe MB (selected size: $STATEFULSIZE MB).
+Free up some space, or choose a larger stateful partition size (-s) or smaller
+crouton partition (-c)."
+    fi
+
+    # Unit: 512 bytes block
+    newstatesize="$((STATEFULSIZE*1024*2))"
+
+    if [ "$newstatesize" -gt "$statesize" ]; then
+        error 1 "Stateful partition size must be less than the current one ($((statesize/(1024*2))) MB)."
+    fi
+
+    croutonsize=$((statesize-newstatesize))
+    croutonstart=$((statestart+newstatesize))
+
+    if [ "$croutonsize" -lt "$((MINIMUMCROUTONSIZE*1024*2))" ]; then
+        error 1 "You must leave at least $MINIMUMCROUTONSIZE MB for the crouton partition."
+    fi
+
+    echo "Overriding partion table entry $CROUTONPARTNUMBER:"
+    cgpt show -i "$CROUTONPARTNUMBER" "$ROOTDEVICE"
+    echo "----"
+    echo "New partition sizes:"
+    echo "    Stateful partition (Chromium OS): $((newstatesize/(2*1024))) MB"
+    freespace=$((newstatesize/(2*1024)-statefulallocated/1024))
+    echo "        Leftover free space: $freespace MB"
+    echo "    crouton: $((croutonsize/(2*1024))) MB"
+    echo "----"
+
+    echo -n "Type 'yes' if you are you satisfied with these new sizes: "
+    read line
+    if [ "$line" != "yes" ]; then
+        error 2 "Aborting..."
+    fi
+fi
+
+echo "====== WARNING ======"
+if [ -n "$DELETE" ]; then
+    echo "This script will now log you off and wipe '$name' (${ROOTDEVICEPREFIX}$CROUTONPARTNUMBER)."
+elif [ -z "$NOCREATE" ]; then
+    echo "This script will now log you off, setup the crouton partition, and reboot."
+else
+    echo "This script will now log you off and unmount the stateful partition."
+fi
+echo "Make sure all your current work is saved."
+
+time=10
+while [ "$time" -gt 0 ]; do
+    printf "\\rYou have %2d seconds to press Ctrl-C to abort..." "$time"
+    sleep 1
+    time="$((time-1))"
+done
+echo
+
+# Unmount crouton partition, if it exists
+if [ -n "$DELETE" -o -n "$NOCREATE" ]; then
+    for mountpoint in `awk \
+            '$1 == "'"${ROOTDEVICEPREFIX}$CROUTONPARTNUMBER"'" { print $2 }' \
+            /proc/mounts`; do
+        if ! umount "$mountpoint"; then
+            error 1 \
+"Cannot unmount partition in '$mountpoint', make sure nothing is using it."
+        fi
+    done
+fi
+
+if grep -q '^[^ ]* /var/run/crouton/' /proc/mounts \
+        || grep -q '^[^ ]* '"$PREFIX"'/chroots' /proc/mounts; then
+    error 1 \
+"Some chroots are mounted. Log out from these, and run this script again."
+fi
+
+( # Fork a subshell, with input/output in VT $LOGVT
+    clear
+
+    # Redefine error function
+    error() {
+        local ecode="$1"
+        shift
+        chvt $LOGVT
+        echo "$*" 1>&2
+        echo "Press enter to reboot..."
+        read line
+        settrap ""
+        sync
+        reboot
+        exit "$ecode" # unreachable
+    }
+
+    addtrap "chvt $LOGVT; echo 'Something went wrong, press enter to reboot.';\
+             read line; echo 'Syncing...'; sync; echo 'Rebooting...'; reboot"
+
+    # Make sure screen does not blank out (setterm does not work in this
+    # context: send control sequence instead)
+    /bin/echo -n -e "\x1b[9;0]\x1b[14;0]"
+
+    # Get out of the stateful partition
+    cd /
+
+    echo "Logging user out..."
+    dbus-send --system --dest=org.chromium.SessionManager --type=method_call \
+        --print-reply /org/chromium/SessionManager \
+        org.chromium.SessionManagerInterface.StopSession \
+        string:"crouton installer"
+
+    # Detect when the user has been logged out
+    tries=10
+    while [ "$tries" -gt 0 ] && grep -q '^/home/.shadow' /proc/mounts; do
+        chvt $LOGVT
+        sleep 1
+        if [ "$tries" -le 5 ]; then
+            echo "Some mounts are still active:"
+            grep '^/home/.shadow' /proc/mounts || true
+            echo "Trying to unmount..."
+            grep '^/home/.shadow' /proc/mounts | cut -f1 -d ' ' \
+		| xargs --no-run-if-empty -d '
+' -n 50 umount || true
+        fi
+        tries="$((tries-1))"
+    done
+
+    # Switch to log VT
+    chvt $LOGVT
+
+    if [ "$tries" = 0 ]; then
+        error 1 "Cannot log user out. Your system has not been modified."
+    fi
+
+    echo "Stopping all services..."
+
+    # Stop all services except tty2. || true is needed as sometimes services
+    # stop dependencies before we can stop them ourselves.
+    initctl list | grep process | cut -f1 -d' ' | grep -v tty2 | \
+            xargs -I{} stop {} || true
+
+    # Make sure we stay on the right VT (some services switch VT when stopped)
+    chvt $LOGVT
+
+    echo "Unmounting stateful partition..."
+    # Try to unmount directories where ${ROOTDEVICEPREFIX}1 and
+    # /dev/mapper/encstateful are mounted. Order by length so that
+    # subdirectories are removed first.
+    for device in "/dev/mapper/encstateful" "${ROOTDEVICEPREFIX}1"; do
+        echo "Unmounting $device..."
+        for path in `awk '
+                    $1 == "'"$device"'" {
+                        sub(/\\\\040\(deleted\)$/, "", $2)
+                        print length($2)":"$2
+                    }' /proc/mounts | sort -nr | cut -d: -f 2`; do
+            echo "Unmounting $path and subdirectories..."
+            for mnt in `awk '
+                            $2 ~ "^'"$path"'($|/)" {
+                                sub(/\\\\040\(deleted\)$/, "", $2)
+                                print length($2)":"$2
+                            }' /proc/mounts | sort -nr | cut -d: -f 2`; do
+		# Replace \040 by space
+		mnt="`echo -n "$mnt" | sed -e 's/\\\\040/ /g'`"
+                pid="`lsof -t +D "$mnt" || true`"
+                if [ -n "$pid" ]; then
+                    # These processes should have terminated already, KILL them
+                    echo "Killing processes in $mnt..."
+                    kill -9 $pid || true
+                fi
+                echo "Unmounting $mnt..."
+                umount "$mnt" 2>/dev/null
+            done
+        done
+
+        if [ "$device" = "/dev/mapper/encstateful" ]; then
+            dmsetup remove "/dev/mapper/encstateful" 2>/dev/null
+            losetup -D 2>/dev/null
+        fi
+    done
+
+    # Just in case, really.
+    chvt $LOGVT
+
+    if grep -q "^${ROOTDEVICEPREFIX}1" /proc/mounts; then
+        error 1 "Cannot unmount stateful partition. Your system has not been modified."
+    fi
+
+    if [ -n "$NOCREATE" ]; then
+        echo "Services were stopped, and stateful partition is unmounted."
+        echo "Press enter to switch back to VT2 (this is VT$LOGVT)."
+        echo "Then login as root, and type reboot when you are done."
+        read line
+        sync
+        chvt 2
+        settrap ""
+        exit 0
+    fi
+
+    if [ -n "$DELETE" ]; then
+        echo "Removing partition $CROUTONPARTNUMBER..."
+        cgpt add -i "$CROUTONPARTNUMBER" -b 0 -s 1 -l "" -t unused "$ROOTDEVICE"
+
+        echo "Resizing stateful partition..."
+        cgpt add -i 1 -s "$newstatesize" "$ROOTDEVICE"
+
+        # Tell the kernel to re-read the partition table
+        partprobe "$ROOTDEVICE"
+
+        # Resize the stateful partition
+        e2fsck -f -p "${ROOTDEVICEPREFIX}1"
+        resize2fs -p "${ROOTDEVICEPREFIX}1"
+    else
+        echo "Resizing stateful partition..."
+        e2fsck -f -p "${ROOTDEVICEPREFIX}1"
+        resize2fs -p "${ROOTDEVICEPREFIX}1" "${newstatesize}s"
+
+        echo "Updating partition table..."
+        cgpt add -i 1 -b "$statestart" -s "$newstatesize" -l STATE "$ROOTDEVICE"
+        cgpt add -i "$CROUTONPARTNUMBER" -t data \
+                 -b "$croutonstart" -s "$croutonsize" -l CROUTON "$ROOTDEVICE"
+
+        # Tell the kernel to re-read the partition table
+        partprobe "$ROOTDEVICE"
+
+        echo "Formatting crouton partition..."
+        mkfs.ext4 "${ROOTDEVICEPREFIX}${CROUTONPARTNUMBER}"
+    fi
+
+    sync
+
+    echo "New partition table:"
+    cgpt show "$ROOTDEVICE" -i 1
+    cgpt show "$ROOTDEVICE" -i "$CROUTONPARTNUMBER"
+
+    echo "Success! Press enter to reboot.."
+    read line
+    settrap ""
+    sync
+    reboot
+) >"/dev/tty$LOGVT" 2>&1 <"/dev/tty$LOGVT" &
+
+wait
+
+error 1 "Cannot start subshell."

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -112,6 +112,23 @@ disablehungtask
 # Set ROOTDEVICE
 findrootdevice
 
+updatestatus="`update_engine_client --status 2>/dev/null | \
+               sed -n "s/CURRENT_OP=\(.*\)$/\1/p"`"
+
+if [ "$updatestatus" != "UPDATE_STATUS_IDLE" ]; then
+    if [ "$updatestatus" = "UPDATE_STATUS_UPDATED_NEED_REBOOT" ]; then
+        error 1 "\
+A Chromium OS update is currently pending, please restart your Chromebook,
+then launch this script again."
+    else
+        error 1 "\
+Chromium OS is currently being updated (status: $updatestatus).
+Please wait for the update to complete (it can be monitored with
+'update_engine_client --update'), then restart your Chromebook, and launch this
+script again."
+    fi
+fi
+
 # Restore stateful partition to its original size
 if [ -n "$DELETE" ]; then
     if [ -z "$CROUTONPARTNUMBERSET" ]; then

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -484,7 +484,8 @@ fi
     read -r line
     settrap ""
     reboot
-) >"/dev/tty$LOGVT" 2>&1 <"/dev/tty$LOGVT" &
+# Tee in /dev/kmsg so that we can read the output in /proc/pstore
+) 2>&1 <"/dev/tty$LOGVT" | tee /dev/kmsg >"/dev/tty$LOGVT" &
 
 wait
 

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -254,6 +254,12 @@ crouton partition (-c)."
     fi
 fi
 
+if grep -q '^[^ ]* '"`readlink -m '/var/run/crouton'`/" /proc/mounts \
+        || grep -q '^[^ ]* '"$PREFIX"'/chroots' /proc/mounts; then
+    error 1 \
+"Some chroots are mounted. Log out from these, and run this script again."
+fi
+
 echo "====== WARNING ======"
 if [ -n "$DELETE" ]; then
     echo "This script will now log you off and wipe '$name' (${ROOTDEVICEPREFIX}$CROUTONPARTNUMBER)."
@@ -282,12 +288,6 @@ if [ -n "$DELETE" -o -n "$NOCREATE" ]; then
 "Cannot unmount partition in '$mountpoint', make sure nothing is using it."
         fi
     done
-fi
-
-if grep -q '^[^ ]* /var/run/crouton/' /proc/mounts \
-        || grep -q '^[^ ]* '"$PREFIX"'/chroots' /proc/mounts; then
-    error 1 \
-"Some chroots are mounted. Log out from these, and run this script again."
 fi
 
 ( # Fork a subshell, with input/output in VT $LOGVT

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -318,7 +318,7 @@ if [ -n "$DELETE" -o -n "$NOCREATE" ]; then
 fi
 
 ( # Fork a subshell, with input/output in VT $LOGVT
-    clear
+    clear || true
 
     # Redefine error function
     error() {

--- a/installer/mkpart.sh
+++ b/installer/mkpart.sh
@@ -162,7 +162,12 @@ if [ -n "$DELETE" ]; then
 WARNING: Removing '$name' partition: ALL DATA ON THAT PARTITION WILL BE LOST.
 
 Type 'delete' if you are sure that you want to do that: "
-    read -r line
+    if [ -t 0 ]; then
+        read -r line
+    else
+        line="$CROUTON_MKPART_DELETE"
+        echo "$line"
+    fi
     if [ "$line" != "delete" ]; then
         error 2 "Aborting..."
     fi
@@ -265,7 +270,12 @@ crouton partition (-c)."
     echo "----"
 
     echo -n "Type 'yes' if you are you satisfied with these new sizes: "
-    read -r line
+    if [ -t 0 ]; then
+        read -r line
+    else
+        line="$CROUTON_MKPART_YES"
+        echo "$line"
+    fi
     if [ "$line" != "yes" ]; then
         error 2 "Aborting..."
     fi

--- a/test/test-mkpart.sh
+++ b/test/test-mkpart.sh
@@ -1,0 +1,169 @@
+#!/bin/sh -e
+# Copyright (c) 2014 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# This is a "server-side" test for mkpart.sh. It requires a DUT with a testing
+# image installed.
+#
+# If run without parameter, it tries to lock all ready pool:crouton machines
+# from autotest, and run tests on them. In that case, cli/ directory from
+# autotest checkout must be in path:
+# export PATH=.../crouton-testing/daemon/autotest.git/cli:$PATH
+
+set -e
+
+# Modify this as needed
+REPO="drinkcat/chroagh"
+BRANCH="separate_partition"
+
+APPLICATION="${0##*/}"
+SCRIPTDIR="`readlink -f "\`dirname "$0"\`/.."`"
+TESTDIR="$SCRIPTDIR/test/run"
+TESTNAME="`sh -e "$SCRIPTDIR/build/genversion.sh" test`"
+TESTDIR="$TESTDIR/$TESTNAME"
+URL="https://github.com/$REPO/archive/$BRANCH.tar.gz"
+SSHOPTS="-o IdentityFile=~/.ssh/testing_rsa -o StrictHostKeyChecking=no \
+-o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"
+
+# Common functions
+. "$SCRIPTDIR/installer/functions"
+
+if [ -z "$1" ]; then
+    hosts="`atest host list -b pool:crouton -s Ready -N --unlocked`"
+    addtrap "atest host mod --unlock $hosts"
+    atest host mod --lock $hosts
+
+    mkdir -p "$TESTDIR"
+    echo "Logging to $TESTDIR"
+
+    for host in $hosts; do
+        (
+            echo "Starting test on $host..." 1>&3
+            if "$0" "$host.cros"; then
+                echo "test on $host succeeded..." 1>&3
+            else
+                echo "test on $host failed..." 1>&3
+            fi
+        ) 3>&1 > "$TESTDIR/$host.log" 2>&1 &
+    done
+
+    wait
+
+    exit 0
+fi
+
+HOST="$1"
+
+ssh_run() {
+    ssh $SSHOPTS root@"$HOST" "sh -exc '$1'"
+}
+
+fetch_crouton() {
+    ssh_run "
+        mkdir -p /tmp/mkpart
+        cd /tmp/mkpart
+        rm -f '$BRANCH.tar.gz'
+        wget '$URL'
+        tar xf '$BRANCH.tar.gz' --strip-components 1"
+}
+
+# wait_host on|off [timeout]
+# Waits for host to appear/disappear
+wait_host() {
+    local on="${1:-on}"
+    local timeout="${2:-300}"
+    echo "Waiting for host to turn $on..."
+    while [ "$timeout" -gt 0 ]; do
+        if [ "$on" = "on" ]; then
+            if ssh_run true >/dev/null 2>&1; then
+                break
+            fi
+        else
+            if ! ssh_run true >/dev/null 2>&1; then
+                break
+            fi
+            sleep 5
+        fi
+        timeout="$((timeout-5))"
+    done
+    if [ "$timeout" -le 0 ]; then
+        echo "Timeout..."
+        exit 1
+    fi
+}
+
+check_no_crouton_partition() {
+    ssh_run '
+        root="`rootdev -d -s`"
+        cgpt show -i 13 "$root"
+        [ "`cgpt show -i 13 -b "$root"`" = 0 ] # begin
+        [ "`cgpt show -i 13 -s "$root"`" = 0 ] # size
+    '
+}
+
+wait_host on 30
+fetch_crouton
+
+# Switch on the screen
+ssh_run "dbus-send --system --dest=org.chromium.PowerManager \
+                   --type=method_call /org/chromium/PowerManager \
+                   org.chromium.PowerManager.HandleUserActivity"
+
+exists=
+echo "Checking crouton partition does not exist..."
+if check_no_crouton_partition; then
+    echo "Creating crouton partition..."
+    ssh_run '
+        cd /tmp/mkpart
+        CROUTON_MKPART_YES=yes sh installer/main.sh -S -c 5000 </dev/null
+    ' &
+    sshpid="$!"
+    wait_host off 120
+    kill "$sshpid"
+    wait_host on 300
+    fetch_crouton
+else
+    echo "ERROR: Partition 13 exists already, deleting it..."
+    exists=y
+fi
+
+# FIXME: We could do more precise begin/size checks
+echo "Checking new partition size..."
+ssh_run '
+    root="`rootdev -d -s`"
+    cgpt show -i 13 "$root"
+    [ "`cgpt show -i 13 -b "$root"`" -gt 0 ] # begin
+    [ "`cgpt show -i 13 -s "$root"`" -gt 0 ] # size
+'
+
+# Restore host-bin (this mounts the partition), then check partition is mounted
+ssh_run '
+    echo "Restoring host-bin..."
+    sh /tmp/mkpart/installer/main.sh -b
+    echo "Checking if the partition was mounted..."
+    cat /proc/mounts | grep "[^ ]* /var/crouton ext4"
+'
+
+echo "Deleting partition..."
+ssh_run '
+    cd /tmp/mkpart
+    CROUTON_MKPART_DELETE=delete sh installer/main.sh -S -d </dev/null
+' &
+sshpid="$!"
+wait_host off 120
+kill "$sshpid"
+wait_host on 300
+
+echo "Checking crouton partition does not exist..."
+check_no_crouton_partition
+
+if [ -n "$exists" ]; then
+    echo "\
+WARNING: Partition 13 was already present at the beginning of the test.
+It was deleted successfully, but the test should be run again."
+    exit 1
+fi
+
+echo "Test completed!"
+exit 0


### PR DESCRIPTION
The times of disastrous wipes and powerwashes are over!

- Create a separate partition for crouton (`/var/crouton`). The scripts stay in `/usr/local/bin`, but the chroots are stored in `/var/crouton/chroots`.
- Autodetect if the partition exists in `enter-chroot` and other scripts. If it does, mount it, and use it.
- Allow to restore scripts with the new `-b` option in the installer.

This is based on #630 (first 3 commits here).

A draft of the companion wiki page is available here: https://github.com/drinkcat/chroagh/wiki/chroots-in-a-separate-partition , I wrote it in way that allows potential testers to try it out before it's merged.