### PR TITLE
audio fixes

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -326,7 +326,9 @@ END
         fi
 
         # CRAS needs to be patched so that x86 client can access x86_64 server
-        if [ "`uname -m`" = "x86_64" ] &&
+        # Applied upstream in build 5652, see http://crbug.com/309961
+        # FIXME: Remove this when 5652 has trickled down to stable
+        if [ "$CROS_VER_1" -lt 5652 ] && [ "`uname -m`" = "x86_64" ] &&
            [ "$ARCH" = "i386" -o "$cras_arch" = "i386" ]; then
             patch_cras_x86_x86_64
         fi


### PR DESCRIPTION
- audio: Fix CRAS bug (hanging cras_test_client): Introduced in upstream version 5339, fixed in version 5579, see http://crbug.com/347997 . Patching until we know if upstream wants to include it in R34-5500 (I guess they won't unless it breaks something else).
- audio: Detect ADHD commit id from manifests if no branch available (typical with XXXX.0.0 builds). Also removed `master` fallback as this should never be required. Fixes the root cause of #711.
- audio: patch_cras_x86_x86_64 is not required anymore on build >=5652. See http://crbug.com/309961. Fixes the symptom in #711.

Tested in `2014-03-20_12-50-20_drinkcat_chroagh_fix-audio-5652_-R_precise_30`.
