### PR TITLE
Do not chmod +s chvt: instead, rely on sudo

### DIFF
--- a/chroot-bin/croutoncycle
+++ b/chroot-bin/croutoncycle
@@ -213,7 +213,7 @@ if [ "${destdisp#:}" = "$destdisp" ]; then
     eval "`host-x11`"
     # Raise the right window after chvting, so that it can update
     if [ "$tty" != 'tty1' ]; then
-        chvt 1
+        sudo -n chvt 1
         sleep .1
     fi
     croutonwmtools raise "${destdisp%"*"}"
@@ -224,7 +224,7 @@ else
     if [ "${dest#[1-9]}" = "$dest" ]; then
         dest='1'
     fi
-    chvt "$dest"
+    sudo -n chvt "$dest"
 fi
 
 CROUTONPIDFILE='/tmp/crouton-lock/clip'

--- a/targets/x11-common
+++ b/targets/x11-common
@@ -21,8 +21,10 @@ ln -sf croutonpowerd /usr/local/bin/xscreensaver-command
 
 # Install xbindkeys and xautomation for key shortcuts and kbd for chvt
 install --minimal xbindkeys xautomation kbd
-# Make chvt SUID root so we don't need to run croutoncycle as root
-chmod u+s /bin/chvt
+# Allow users to run sudo chvt without password, so we don't need to run
+# croutoncycle as root
+echo '%sudo ALL = NOPASSWD:/bin/chvt' > /etc/sudoers.d/chvt
+chmod 440 /etc/sudoers.d/chvt
 
 # Add a blank Xauthority to all users' home directories
 touch /etc/skel/.Xauthority


### PR DESCRIPTION
The SUID flag may be lost on update, and relying on sudo is
slightly more secure.

We create a file in /etc/sudoers.d/ : these files are sourced by
default since sudo 1.7.2p1-1 (Ubuntu 10.04 lucid, Debian squeeze).

Fixes #723.
