### PR TITLE
ubuntu/bootstrap: Fix debootstrap download fallback.

### DIFF
--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -16,17 +16,17 @@ if ! wget -O- --no-verbose --timeout=60 -t2 "$d"  \
     echo 'Download from Debian gitweb failed. Trying latest release...' 1>&2
     d='http://ftp.debian.org/debian/pool/main/d/debootstrap/'
     f="`wget -O- --no-verbose --timeout=60 -t2 "$d" \
-            | sed -ne 's ^.*\(debootstrap_[0-9.]*.tar.gz\).*$ \1 p' \
+            | sed -ne 's ^.*\(debootstrap_[0-9.]*.tar.xz\).*$ \1 p' \
             | tail -n 1`"
     if [ -z "$f" ]; then
         error 1 'Failed to download debootstrap.
 Check your internet connection or proxy settings and try again.'
     fi
     v="${f#*_}"
-    v="${v%.tar.gz}"
+    v="${v%.tar.xz}"
     echo "Downloading debootstrap version $v..." 1>&2
     if ! wget -O- --no-verbose --timeout=60 -t2 "$d$f" \
-            | tar -C "$tmp" --strip-components=1 -zx 2>/dev/null; then
+            | tar -C "$tmp" --strip-components=1 -Jx 2>/dev/null; then
         error 1 'Failed to download debootstrap.'
     fi
 fi


### PR DESCRIPTION
Now it's a `.tar.xz` file, instead of `.tar.gz`. Should fix #740.
