### PR TITLE
croutonxinitrc-wrapper: Maximize Xephyr on startup

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -77,8 +77,10 @@ mkdir -m 775 -p /tmp/crouton-lock
 
 # Pass through the host cursor and correct mousewheels on xephyr
 if [ "$xmethod" = 'xephyr' ]; then
-    # Recent versions of Xephyr (>=1.15) do not start in full screen:
-    # tell croutonwmtools to maximize it
+    # Xephyr (versions >=1.15.0, <1.15.0.902) does not properly resize its
+    # window: tell croutonwmtools to maximize it
+    # FIXME: Remove this when these versions are not used by any supported
+    # distro anymore (see https://github.com/dnschneid/crouton/pull/750)
     host-x11 croutonwmtools r "`host-x11 croutonwmtools l 1`"
 
     host-x11 croutoncursor "$DISPLAY" &


### PR DESCRIPTION
Recent versions of Xephyr (>=1.15) do not start in full screen: tell croutonwmtools to maximize it.

Fixes #744.
