### PR TITLE
croutonxinitrc-wrapper: Make sure xbindkeys is killed on exit.

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -72,7 +72,9 @@ mkdir -m 775 -p /tmp/crouton-lock
 {
     # Only let one instance *really* run at a time
     flock 3
-    XMETHOD='' host-x11 xbindkeys -n -fg /etc/crouton/xbindkeysrc.scm
+    XMETHOD='' host-x11 xbindkeys -n -fg /etc/crouton/xbindkeysrc.scm &
+    trap "kill '$!' 2>/dev/null" HUP INT TERM
+    wait "$!"
 } 3>/tmp/crouton-lock/xbindkeys &
 
 # Pass through the host cursor and correct mousewheels on xephyr


### PR DESCRIPTION
Steps to reproduce:
- `enter-chroot` in a first crosh
- `startxfce4` in a second crosh, then press Ctrl-C.

`ps -eaf` shows that xbindkeys is still running. However, its parent is now PID 1, and it received a SIGHUP (due to the parent shell process terminating).
Unfortunately, xbindkeys does not handle SIGHUP correctly, and hangs forever (locked in a `futex` call according to ptrace: did not investigate further), and does not process any further key presses.

This might explain #754, and some similar bugs reported on Google+.
