### PR TITLE
test/30-audio: Install recommended deps for pulseaudio

### DIFF
--- a/test/tests/30-audio
+++ b/test/tests/30-audio
@@ -42,7 +42,7 @@ for release in $SUPPORTED_RELEASES; do
         '
     fi
 
-    echo 'install --minimal pulseaudio pulseaudio-utils' | \
+    echo 'install pulseaudio pulseaudio-utils' | \
             crouton -T -U -n "$release"
     host enter-chroot -n "$release" sh -exc '
         pulseaudio --start


### PR DESCRIPTION
pulseaudio 5.0 on jessie (and probably sid) requires `dbus-daemon` to be running in its default configuration. However, `install --minimal pulseaudio` does not pull in dbus.

Removing `--minimal` ensures dbus is installed, as it would be in most real cases.
