### PR TITLE
Test if kernels are signed before setting dev_boot_signed_only=1

### DIFF
--- a/installer/functions
+++ b/installer/functions
@@ -35,60 +35,6 @@ installscript() {
     1' "$src" | sed -e "${3:-;}" > "$dst"
 }
 
-# Verify if kernels are signed: We use this to decide if we should set
-# dev_boot_signed_only=1. We are conservative, and only return 0 if all bootable
-# kernels are signed with factory keys.
-# We do not take non-bootable kernels into account, as those will be ignored
-# during the boot process (e.g. KERN-C in a typical setup), or, if no
-# bootable kernel is present, the Chromebook will not boot no matter the value
-# of dev_boot_signed_only.
-# This is only used in main.sh and a test script, so it does not need
-# to be inserted in other scripts.
-verifykernelsig() {
-    echo 'Checking if kernels are verified...' 1>&2
-    ( dev_debug_vboot -c -i "`rootdev -s -d`" && echo "OK" ) | awk '
-        # Print every line
-        1
-        # Detect end of kernel "section"
-        !/^  / {
-            partition = ""
-        }
-        /^Kernel / {
-            partition=$2
-            sub(/:$/, "", partition)
-
-            # Only consider kernels whose header is valid
-            if ($3 == "OK") {
-                okkernel[partition] = 0
-            } else {
-                partition = ""
-            }
-        }
-        # Accept either kern_subkey_A or kern_subkey_B (ignore recovery key)
-        partition && /^  Verify / && $4 ~ /^kern_subkey_[AB].vbpubk:$/ {
-            if ($5 == "OK") {
-                okkernel[partition] = 1
-            }
-        }
-
-        END {
-            if ($0 != "OK") {
-                print "Error running dev_debug_vboot."
-                exit 1
-            }
-            ret=0
-            for (part in okkernel) {
-                if (!okkernel[part]) {
-                    print "Kernel " part " is not verified."
-                    ret=1
-                }
-            }
-            if (!ret) print "All bootable kernels are verified."
-            exit ret
-        }
-    ' 1>&2
-}
-
 ### Everything after this line will be statically inserted into scripts.
 
 # Exits the script with exit code $1, spitting out message $@ to stderr

--- a/installer/functions
+++ b/installer/functions
@@ -35,6 +35,60 @@ installscript() {
     1' "$src" | sed -e "${3:-;}" > "$dst"
 }
 
+# Verify if kernels are signed: We use this to decide if we should set
+# dev_boot_signed_only=1. We are conservative, and only return 0 if all bootable
+# kernels are signed with factory keys.
+# We do not take non-bootable kernels into account, as those will be ignored
+# during the boot process (e.g. KERN-C in a typical setup), or, if no
+# bootable kernel is present, the Chromebook will not boot no matter the value
+# of dev_boot_signed_only.
+# This is only used in main.sh and a test script, so it does not need
+# to be inserted in other scripts.
+verifykernelsig() {
+    echo 'Checking if kernels are verified...' 1>&2
+    ( dev_debug_vboot -c -i "`rootdev -s -d`" && echo "OK" ) | awk '
+        # Print every line
+        1
+        # Detect end of kernel "section"
+        !/^  / {
+            partition = ""
+        }
+        /^Kernel / {
+            partition=$2
+            sub(/:$/, "", partition)
+
+            # Only consider kernels whose header is valid
+            if ($3 == "OK") {
+                okkernel[partition] = 0
+            } else {
+                partition = ""
+            }
+        }
+        # Accept either kern_subkey_A or kern_subkey_B (ignore recovery key)
+        partition && /^  Verify / && $4 ~ /^kern_subkey_[AB].vbpubk:$/ {
+            if ($5 == "OK") {
+                okkernel[partition] = 1
+            }
+        }
+
+        END {
+            if ($0 != "OK") {
+                print "Error running dev_debug_vboot."
+                exit 1
+            }
+            ret=0
+            for (part in okkernel) {
+                if (!okkernel[part]) {
+                    print "Kernel " part " is not verified."
+                    ret=1
+                }
+            }
+            if (!ret) print "All bootable kernels are verified."
+            exit ret
+        }
+    ' 1>&2
+}
+
 ### Everything after this line will be statically inserted into scripts.
 
 # Exits the script with exit code $1, spitting out message $@ to stderr

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -446,6 +446,58 @@ Refer to http://goo.gl/Z5LGVD for upgrade instructions." 1>&2
     sleep 5
 fi
 
+# Verify if kernels are signed: We use this to decide if we should set
+# dev_boot_signed_only=1. We are conservative, and only return 0 if all bootable
+# kernels are signed with factory keys.
+# We do not take non-bootable kernels into account, as those will be ignored
+# during the boot process (e.g. KERN-C in a typical setup), or, if no
+# bootable kernel is present, the Chromebook will not boot no matter the value
+# of dev_boot_signed_only.
+verifykernelsig() {
+    echo 'Checking if kernels are verified...' 1>&2
+    ( dev_debug_vboot -c -i "`rootdev -s -d`" && echo "OK" ) | awk '
+        # Print every line
+        1
+        # Detect end of kernel "section"
+        !/^  / {
+            partition = ""
+        }
+        /^Kernel / {
+            partition=$2
+            sub(/:$/, "", partition)
+
+            # Only consider kernels whose header is valid
+            if ($3 == "OK") {
+                okkernel[partition] = 0
+            } else {
+                partition = ""
+            }
+        }
+        # Accept either kern_subkey_A or kern_subkey_B (ignore recovery key)
+        partition && /^  Verify / && $4 ~ /^kern_subkey_[AB].vbpubk:$/ {
+            if ($5 == "OK") {
+                okkernel[partition] = 1
+            }
+        }
+
+        END {
+            if ($0 != "OK") {
+                print "Error running dev_debug_vboot."
+                exit 1
+            }
+            ret=0
+            for (part in okkernel) {
+                if (!okkernel[part]) {
+                    print "Kernel " part " is not verified."
+                    ret=1
+                }
+            }
+            if (!ret) print "All bootable kernels are verified."
+            exit ret
+        }
+    ' 1>&2
+}
+
 verifykernelpid=''
 # Tips that should be displayed if the installer succeeds
 crossystemtips=''

--- a/test/tests/19-verifykernel
+++ b/test/tests/19-verifykernel
@@ -5,8 +5,8 @@
 
 # Check that current kernels are verified, if we are running an official image
 if grep '^CHROMEOS_RELEASE_NAME=Chrome OS$' /etc/lsb-release; then
-    passes from 'installer/main.sh' import verifykernelsig
-    passes verifykernelsig
+    from 'installer/main.sh' import verifykernelsig
+    verifykernelsig
 else
     log "Non-official image: skipping kernel verification test."
 fi

--- a/test/tests/19-verifykernel
+++ b/test/tests/19-verifykernel
@@ -6,7 +6,7 @@
 # Check that current kernels are verified, if we are running an official image
 if grep '^CHROMEOS_RELEASE_NAME=Chrome OS$' /etc/lsb-release; then
     from 'installer/main.sh' import verifykernelsig
-    verifykernelsig
+    passes verifykernelsig
 else
     log "Non-official image: skipping kernel verification test."
 fi

--- a/test/tests/19-verifykernel
+++ b/test/tests/19-verifykernel
@@ -5,7 +5,7 @@
 
 # Check that current kernels are verified, if we are running an official image
 if grep '^CHROMEOS_RELEASE_NAME=Chrome OS$' /etc/lsb-release; then
-    # installer/functions is sourced in run.sh
+    passes from 'installer/main.sh' import verifykernelsig
     passes verifykernelsig
 else
     log "Non-official image: skipping kernel verification test."

--- a/test/tests/19-verifykernel
+++ b/test/tests/19-verifykernel
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+# Copyright (c) 2014 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Check that current kernels are verified, if we are running an official image
+if grep '^CHROMEOS_RELEASE_NAME=Chrome OS$' /etc/lsb-release; then
+    # installer/functions is sourced in run.sh
+    passes verifykernelsig
+else
+    log "Non-official image: skipping kernel verification test."
+fi


### PR DESCRIPTION
This has been discussed extensively in #765.
- The verification has been modified a little: We check all bootable kernels (instead of hardcoding `KERN-A` and `KERN-B`). This should play better with Chrubuntu.
- We start the kernel verification process in parallel with bootstrapping.
- After boostrapping is done, we check the status, and enable `dev_boot_signed_only` if required.
- We inform the user of the modification in a trap, so it's displayed in all cases.
- Warnings regarding USB/legacy booting are only displayed on success (it's less critical to display them).

I also provide a test, and the function is put in `installer/functions`, before `###`, so it's not included in `host|chroot-bin` files.
