### PR TITLE
Revert "Merge pull request #750 from drinkcat/xephyr-fullscreen"

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -79,12 +79,6 @@ mkdir -m 775 -p /tmp/crouton-lock
 
 # Pass through the host cursor and correct mousewheels on xephyr
 if [ "$xmethod" = 'xephyr' ]; then
-    # Xephyr (versions >=1.15.0, <1.15.0.902) does not properly resize its
-    # window: tell croutonwmtools to maximize it
-    # FIXME: Remove this when these versions are not used by any supported
-    # distro anymore (see https://github.com/dnschneid/crouton/pull/750)
-    host-x11 croutonwmtools r "`host-x11 croutonwmtools l 1`"
-
     host-x11 croutoncursor "$DISPLAY" &
     if [ -z "$CROUTON_WHEEL_PARAMS" -a -r "$HOME/.croutonwheel" ]; then
         CROUTON_WHEEL_PARAMS="`head -n1 "$HOME/.croutonwheel"`"


### PR DESCRIPTION
Upstream bug has been fixed in xorg-xephyr 1.15.1, and this version is
now packaged in all affected releases.

This reverts commit f9ed015f64dacea14d70c019f62e00b88a81a803, reversing
changes made to 23bb77d4abb1b8e876566129ea717b2796de323e.
