### PR TITLE
use ~/Downloads as home directory for chroot user

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -375,10 +375,10 @@ if ! mountpoint -q "$destmedia"; then
     mount --rbind /media "$destmedia"
 fi
 
-# Bind-mount ~/Downloads if we're logged in as a user
+# Bind-mount ~/Downloads as home directory if we're logged in as a user
 localdownloads='/home/chronos/user/Downloads'
 if [ -z "$NOLOGIN" -a -n "$CHROOTHOME" -a -d "$localdownloads" ]; then
-    bindmount "$localdownloads" "$CHROOTHOME/Downloads" exec
+    bindmount "$localdownloads" "$CHROOTHOME" exec
 fi
 
 # For test machines with low entropy, bind mount /dev/urandom to /dev/random


### PR DESCRIPTION
This patch mounts your ~/Downloads directory as the home directory for
the main user in all of your Crouton chroots.  By doing this, you get:
- easy access to files in/beneath your home directory from Chromium OS
- an encrypted home directory because ~/Downloads is already encrypted
- the same, persistent home directory across different Crouton chroots
