### PR TITLE
croutonxinitrc-wrapper: Make sure children do not ignore signals

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -109,8 +109,10 @@ fi
 
 # Shell is the leader of a process group, so signals sent to this process are
 # propagated to its children. We ignore signals in this process, but the child
-# handles them and exits. This process then runs exit commands, and terminates.
-trap "" HUP INT TERM
+# handles them and exits. We use a no-op handler, as "" causes the signal to be
+# ignored in children as well (see NOTES in "man 2 sigaction" for details).
+# This process then runs exit commands, and terminates.
+trap "true" HUP INT TERM
 
 # Run the client itself if it is executable, otherwise run it in a shell.
 ret=0


### PR DESCRIPTION
Creating a child resets signal handlers, but leaves ignored signals
unchanged (see "man 2 sigaction" for details): replace "" with a
no-op handler "true".

Test:
- Logout in LXDE works (fixes #851)
- Ctrl-C in crosh, or sending SIGTERM to xinit both work (exit
  commands are run).
