### PR TITLE
mount chrootfs read-only at ~/Downloads/crouton-*

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -377,6 +377,17 @@ fi
 localdownloads='/home/chronos/user/Downloads'
 if [ -z "$NOLOGIN" -a -n "$CHROOTHOME" -a -d "$localdownloads" ]; then
     bindmount "$localdownloads" "$CHROOTHOME/Downloads" exec
+
+    # Bind-mount $CHROOT read-only into ~/Downloads/crouton-$NAME so that we
+    # can access files in the chroot directly from Chromium OS' "Files" app
+    localchroot="$localdownloads/crouton-$NAME"
+    if ! mountpoint -q "$localchroot"; then
+        mkdir -p "$localchroot"
+        # Running `mount --bind -o ro` doesn't work: we need to mount first
+        # and then remount read-only.  See https://lwn.net/Articles/281157/
+        mount --bind "$CHROOT" "$localchroot"
+        mount --bind -o remount,ro "$localchroot"
+    fi
 fi
 
 # Bind-mount /sys recursively, making it a slave in the chroot

--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -314,6 +314,13 @@ for NAME in "$@"; do
     if [ -n "$oldstyle" ]; then
         unmount "$NAME"
     fi
+
+    # Unmount bind-mounted read-only $CHROOT from ~/Downloads/crouton-$NAME
+    localdownloads='/home/chronos/user/Downloads'
+    localchroot="$localdownloads/crouton-$NAME"
+    if mountpoint -q "$localchroot"; then
+        umount "$localchroot" && rmdir "$localchroot" || : # ignore failures
+    fi
 done
 
 # Re-disable USB persistence (the Chromium OS default) if we no longer


### PR DESCRIPTION
This patch bind-mounts $CHROOT read-only into ~/Downloads/crouton-$NAME if
we're logged in as a user so that we can access files in the chroot directly
from Chromium OS' "Files" application (e.g. to upload files).

In addition, mounting read-only protects us from the danger of Chromium OS
deleting files randomly from ~/Downloads whenever disk space is low:

  https://support.google.com/chromebook/answer/1061547

In fact, even the root user cannot delete files from or modify files within a
read-only mount without first remounting it as read-write!

CAVEAT: I'm assuming that Chromium OS is not so aggressive in freeing up disk
space that it would find and remount this bind-mount as read-write.
