### PR TITLE
umount-chroot: Call umount one mount point at a time

### DIFF
--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -236,11 +236,11 @@ unmount() {
     # umount them with and without the suffix (in the unlikely case the mount
     # point actually ends with ' (deleted)')
     # umount has a bug and may return 0 when many mount points cannot be
-    # unmounted, so we call it once per mount point ('-L 1')
+    # unmounted, so we call it once per mount point ('-n 1')
     while ! sed "s=\\\\040=//=g" /proc/mounts | cut -d' ' -f2 | filter \
               | sed -e 's=//= =g;s/^\(\(.*\) (deleted)\)$/\1\n\2/' \
               | sort -r | xargs --no-run-if-empty -d '
-' -n 50 -L 1 umount 2>/dev/null; do
+' -n 1 umount 2>/dev/null; do
         if [ "$ntries" -eq "$TRIES" ]; then
             # Send signal to all processes running under the chroot
             # ...but confirm first.


### PR DESCRIPTION
umount, called with multiple parameters, may return 0 when many mount points cannot be unmounted, due to an overflow in its exit code (see https://github.com/karelzak/util-linux/pull/96). We are unlucky enough to have exactly 8 umount failures (8*32=256 overflows to 0, meaning success), which leads `unmount-chroot` not to attempt to kill processes (including xbindkeys). Then it appears that we hit the bug in `xbindkeys` (#759), and it does not react to further keystrokes.

We fix this by passing `-L 1` to `xargs`.

Finally, we sort mount points to minimize the number of loops required (so subdirectories are unmounted first).

This fixes part of the problem in #754. But I think `croutonxinitrc-wrapper` should still kill xbindkeys properly (it does on SIGHUP/SIGTERM, but not on normal exit), and not rely on `unmount-chroot`. I'll fix that too.
