### PR TITLE
croutonxinitrc-wrapper: Fix xbindkeys kill with dash

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -74,7 +74,7 @@ mkdir -m 775 -p /tmp/crouton-lock
     flock 3
     XMETHOD='' host-x11 xbindkeys -n -fg /etc/crouton/xbindkeysrc.scm &
     trap "kill '$!' 2>/dev/null" HUP INT TERM
-    wait "$!"
+    wait "$!" || true
 } 3>/tmp/crouton-lock/xbindkeys &
 
 # Pass through the host cursor and correct mousewheels on xephyr


### PR DESCRIPTION
#759 was not working as intended with dash:

`wait "$!"` returns a >0 exit code when interrupted by a signal.
bash still executes the signal handler, then quits (`-e`), while dash bails out immediately without running the handler, leaving xbindkeys with PID 1 as parent.
