### PR TITLE
targets/xorg: Install lts-saucy drivers on precise for Haswell support

### DIFF
--- a/targets/xorg
+++ b/targets/xorg
@@ -15,12 +15,10 @@ CHROOTETC='xbindkeysrc.scm xserverrc-x11 xserverrc-local.example'
 ### Append to prepare.sh:
 XMETHOD="${XMETHOD:-x11}"
 
-# Check for Haswell PCI id
-if grep -q 0x8086 /sys/class/graphics/fb0/device/vendor 2>/dev/null && \
-        grep -q 0x0a /sys/class/graphics/fb0/device/device 2>/dev/null && \
-        release -eq precise; then
-    # On precise, install lts-saucy xorg to provide Haswell support
-    # (we still install xorg later to pull in its dependencies)
+# On precise, install lts-saucy xorg server to support newer hardware if kernel
+# version != 3.4 (lts-saucy mesa requires version >=3.6)
+if release -eq precise && ! uname -r | grep -q "^3.4."; then
+    # We still install xorg later to pull in its dependencies
     install --minimal xserver-xorg-lts-saucy libgl1-mesa-glx-lts-saucy \
         xserver-xorg-input-synaptics-lts-saucy
 fi


### PR DESCRIPTION
We first pull in `lts-saucy` replacement drivers, then `xorg`:
- Doing it in that order still pulls in `xorg` dependencies like
  `xterm` and `xinit`, and avoids the need to specify them manually.
- Removing `--minimal` from the `lts-saucy` line also works, but
  also pulls in stuff like an updated kernel, which we don't want.
- Installing `xorg` after `lts-saucy` does not install old drivers
  (so there is no useless download).
- On existing chroots, installing `lts-saucy` uninstalls old drivers,
  and marks a number of packages as not required, like `xterm` and
  `xinit` (which would be cleaned later by autoclean). Reinstalling
  `xorg` does not install new packages, but makes sure these packages
  are not autocleaned.

Tested:
- Current HEAD installer, `-t xorg`, then update with this branch: no important package is added or removed.
- Fresh install with this branch: installed packages are same as case above.
- On `peppy`, direct switching between Chrome OS and crouton works with `lts-saucy` drivers (fixes #754, #870, #884 and a few others).

Also tested with the (not yet mature) x11 test infrastructure, formatted output here: http://drinkcat.github.io/chroagh/2014-06-17_01-22-27_drinkcat_chroagh_x11test.tmp-add-saucy-lts_35.html . The important bit here is that we have OpenGL acceleration in `precise` on all x86 platforms (fixes #639).
