### PR TITLE
The GTK-Pixbuf package is required to render GTK2 elements correctly

### DIFF
--- a/targets/gnome
+++ b/targets/gnome
@@ -11,7 +11,8 @@ CHROOTBIN='startgnome gnome-session-wrapper'
 ### Append to prepare.sh:
 install --minimal evolution-data-server gnome-control-center \
         gnome-screensaver gnome-session gnome-session-fallback \
-        gnome-shell gnome-themes-standard gvfs-backends nautilus unzip
+        gnome-shell gnome-themes-standard gvfs-backends nautilus \
+        unzip gtk2-engines-pixbuf
 
 TIPS="$TIPS
 You can start GNOME via the startgnome host command: sudo startgnome


### PR DESCRIPTION
Without the Pixbuf package in the GNOME target, GTK2 windows such as the Firefox preferences UI and Terminator preferences UI fall back to blocky interface elements such as dropdowns and buttons.
