### PR TITLE
Use /run instead of /var/run as ROOT

### DIFF
--- a/host-bin/mount-chroot
+++ b/host-bin/mount-chroot
@@ -12,10 +12,7 @@ CREATE=''
 ENCRYPT=''
 KEYFILE=''
 PRINT=''
-ROOT='/var/run/crouton'
-if [ -d '/run' ]; then
-    ROOT='/run/crouton'
-fi
+ROOT="`readlink -m '/var/run/crouton'`"
 MOUNTOPTS='rw,dev,exec,suid'
 
 USAGE="$APPLICATION [options] name [...]

--- a/host-bin/unmount-chroot
+++ b/host-bin/unmount-chroot
@@ -15,10 +15,7 @@ PRINT=''
 SIGNAL='TERM'
 TRIES=5
 YES=''
-ROOT='/var/run/crouton'
-if [ -d '/run' ]; then
-    ROOT='/run/crouton'
-fi
+ROOT="`readlink -m '/var/run/crouton'`"
 
 USAGE="$APPLICATION [options] name [...]
 


### PR DESCRIPTION
Chromium OS ToT now uses `/run` in anticipation of a udev uprev, with `/var/run` being a symlink for compatibility. `fixabslinks` assumes no symlink in the `CHROOT` variable, so `/run` should be used directly when passing paths to fixabslinks.

Otherwise, `fixabslinks` will get stuck in an infinite loop in `enter-chroot`.
