### PR TITLE
Unit testing: add tool to import functions from scripts

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -335,6 +335,40 @@ fails() {
     return 0
 }
 
+# Sources a function from a script for unit testing.
+# Note that the function may need global variables defined when run.
+# Usage:
+#   from scriptfile import functionA[[,] functionB]*
+# scriptfile should be tarball-relative, i.e., host-bin/mount-chroot
+from() {
+    local scriptpath="$SCRIPTDIR/$1" scriptfile="$1" name script
+    if [ "$2" != 'import' -o -z "$3" ]; then
+        echo "    $*
+SyntaxError: invalid syntax" 1>&2
+        return 2
+    fi
+    if [ ! -f "$scriptpath" ]; then
+        echo "ImportError: No module named $scriptfile" 1>&2
+        return 2
+    fi
+    shift 2
+    for name in "$@"; do
+        name="${name%,}"
+        script="`awk '
+            /^'"$name"'[(][)] {$/ {x=1}
+            x;
+            x && /^}$/ {exit}
+        ' "$scriptpath"`"
+        if [ -z "$script" ]; then
+            echo "ImportError: cannot import name $name" 1>&2
+            return 2
+        fi
+        log "Importing $name from $scriptfile"
+        eval "$script"
+    done
+    return 0
+}
+
 # Default responses to questions
 export CROUTON_USERNAME='test'
 export CROUTON_PASSPHRASE='hunter2'

--- a/test/tests/00-tester
+++ b/test/tests/00-tester
@@ -17,6 +17,15 @@ exitswithin 0 1 true
 exitswithin 1 1 false
 runslongerthan 1 sleep 2
 
+# Test "from" function importer by faking it out
+: '
+fromtester() {
+    return 0
+}
+'
+passes from 'test/tests/00-tester' import fromtester
+passes fromtester
+
 log 'BEGIN INTENTIONALLY FAILING TESTS'
 ! test 1 -eq 0
 ! passes false
@@ -26,4 +35,6 @@ log 'BEGIN INTENTIONALLY FAILING TESTS'
 ! exitswithin 0 1 sleep 2
 ! runslongerthan 1 false
 ! runslongerthan 1 true
+fails from sys import posix
+fails from 'test/tests/00-tester' import python
 log 'END INTENTIONALLY FAILING TESTS'


### PR DESCRIPTION
As requested in #785.

Python is really good about enabling unit testing, so by stealing its syntax, crouton in turn should have very good unit tests.  Right?  Right?
