### PR TITLE
enter-chroot: mount a local dir as the home dir, if present.

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -373,6 +373,12 @@ if ! mountpoint -q "$destmedia"; then
     mount --rbind /media "$destmedia"
 fi
 
+# Bind-mount ~/localuserhome-$NAME as the home directory, it it exists
+localuserhome="/home/chronos/user/localuserhome-$NAME"
+if [ -z "$NOLOGIN" -a -n "$CHROOTHOME" -a -d "$localuserhome" ]; then
+    bindmount "$localuserhome" "$CHROOTHOME/" exec
+fi
+
 # Bind-mount ~/Downloads if we're logged in as a user
 localdownloads='/home/chronos/user/Downloads'
 if [ -z "$NOLOGIN" -a -n "$CHROOTHOME" -a -d "$localdownloads" ]; then


### PR DESCRIPTION
Situation: I don't like to encrypt the whole chroot, but I'd like my home directory (in chroot) to be encrypted on disk. The solution suggested [here](http://digitalconsumption.com/forum/721-Crouton-Encrypted-User-Folders) is to 'piggyback' on the ecryptfs present in Chrome OS, pretty much the way `Downloads` directory works.

So, the patch changes the `enter-chroot` script, and what is does is that it checks whether there is a directory named `localuserhome-${chroot-name}` in `/home/chronos/user`, and it there is, it bind-mounts it as user's home directory in the chroot.

I've been using it without problems for a while, but there might be some collisions in the grand scheme of things that I'm not aware of.
