### PR TITLE
enter-chroot: If XAUTHORITY is not set, make a guess

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -264,11 +264,13 @@ mkdir -p "$CHROOT/var/host"
 cp -f '/etc/lsb-release' "$CHROOT/var/host/"
 
 # Copy the latest Xauthority into the chroot
-cp -f "$XAUTHORITY" "$CHROOT/var/host/Xauthority"
-chmod 444 "$CHROOT/var/host/Xauthority"
-# Be backwards-compatible, just in case
-if [ -f "$CHROOT/etc/X11/host-Xauthority" ]; then
-    ln -sfT '/var/host/Xauthority' "$CHROOT/etc/X11/host-Xauthority"
+if [ -f "${XAUTHORITY:=/home/chronos/.Xauthority}" ]; then
+    cp -f "$XAUTHORITY" "$CHROOT/var/host/Xauthority"
+    chmod 444 "$CHROOT/var/host/Xauthority"
+    # Be backwards-compatible, just in case
+    if [ -f "$CHROOT/etc/X11/host-Xauthority" ]; then
+        ln -sfT '/var/host/Xauthority' "$CHROOT/etc/X11/host-Xauthority"
+    fi
 fi
 
 # Prepare chroot filesystem


### PR DESCRIPTION
Useful when enter-chroot is called from udev/upstart, see #929.
