### PR TITLE
enter-chroot: Bind mount /run/udev on newer versions of udev

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -362,12 +362,11 @@ ln -sfT /dev/shm "`fixabslinks '/var/run'`/shm"
 
 # Setup udev control directory in the chroot
 # Chromium OS >=6092 uses /run/udev, older versions /dev/.udev
-if [ -d /dev/.udev ]; then
+if [ -d /var/run/udev ]; then
+    bindmount /var/run/udev
+else
     # Add a /run/udev symlink for later versions of udev in chroot
     ln -sfT /dev/.udev "`fixabslinks '/var/run'`/udev"
-else
-    bindmount /var/run/udev /var/host/udev
-    ln -sfT /var/host/udev "`fixabslinks '/var/run'`/udev"
 fi
 
 # Add a /var/host/cras symlink for CRAS clients


### PR DESCRIPTION
udev control directory in Chromium OS >=6092 moved from `/dev/.udev` to `/run/udev`.

This commit makes sure it is accessible from the chroot (e.g. from X server).

In the chroot, udev shipped with precise/wheezy (version 175) is fine with just `/run/udev`, so there is no need to provide `/dev/.udev` as well.

Test: `sudo udevadm info --export-db | grep INPUT` should show some 40 lines of output.
