### PR TITLE
Revert "enter-chroot: Simply bind mount /var/run/udev" (+ invert test)

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -363,7 +363,8 @@ ln -sfT /dev/shm "`fixabslinks '/var/run'`/shm"
 # Setup udev control directory in the chroot
 # Chromium OS >=6092 uses /run/udev, older versions /dev/.udev
 if [ -d /var/run/udev ]; then
-    bindmount /var/run/udev
+    bindmount /var/run/udev /var/host/udev
+    ln -sfT /var/host/udev "`fixabslinks '/var/run'`/udev"
 else
     # Add a /run/udev symlink for later versions of udev in chroot
     ln -sfT /dev/.udev "`fixabslinks '/var/run'`/udev"


### PR DESCRIPTION
This (partially) reverts commit 24c160cee85d781d74c0018936936091a64337ad.

See #966.

Bind mounting in `/var/run` is really a bad idea: we need to hardcode the path in `installer/prepare/ubuntu`, or run another find/xargs expression.

Bind mounting to `/var/host` is simpler, and works just fine.

People who have a chroot running with the current HEAD, on dev channel, must exit the chroot before updating (`enter-chroot` would fail: I do not want to add an extra test for such a short-lived commit).

Sorry about that one, I should have tested it (we miss you autotesters....)...
