### PR TITLE
croutonwheel: Invert vertical scrolling direction

### DIFF
--- a/chroot-bin/croutonwheel
+++ b/chroot-bin/croutonwheel
@@ -121,11 +121,11 @@ flock 3
                 y -= tp ? log(-dy) * '"$ys"' + '"$yc"' : 1
             }
             while (y >= 1) {
-                output("mouseclick '"$d"'")
+                output("mouseclick '"$u"'")
                 y -= 1
             }
             while (y <= -1) {
-                output("mouseclick '"$u"'")
+                output("mouseclick '"$d"'")
                 y += 1
             }
         }


### PR DESCRIPTION
Handling of input events was changed recently in Chromium OS, and the default behaviour in Xephyr is now always the opposite of the one in Chromium OS (setting traditional scrolling in Chromium OS
leads to Australian in Xephyr, and vice-versa).

With this patch, they are in sync (updating setting in Chrome OS changes Xephyr's behaviour as well).

Current users who applied a workaround will need to revert it. But that should be ok: if they knew how to apply it, they should know how to remove it.

Tested on `peach_pit`, stable (5978.80.0) + beta (6158.12.0) (dev==channel for now).
