### PR TITLE
Croutonclip: fix signal handling

### DIFF
--- a/chroot-bin/croutonclip
+++ b/chroot-bin/croutonclip
@@ -49,13 +49,13 @@ copyclip() {
     # if current == next. Also set current=$next if $current is empty
     if [ -z "$next" -o "${current:="$next"}" = "$next" ]; then
         if [ -n "$VERBOSE" ]; then
-            echo "==Current: $current==Next: $next=="
+            echo "==Current: $current==Next: $next==" 1>&2
         fi
         return 0
     fi
 
     if [ -n "$VERBOSE" ]; then
-        echo ">>Current: $current>>"
+        echo ">>Current: $current>>" 1>&2
     fi
 
     # Copy clipboard content from the current display
@@ -103,7 +103,7 @@ copyclip() {
     ) && current="$next"
 
     if [ -n "$VERBOSE" ]; then
-        echo "<<Next: $current<<"
+        echo "<<Next: $current<<" 1>&2
     fi
 }
 
@@ -113,7 +113,7 @@ waitwebsocket() {
     timeout=10
     while [ $timeout -gt 0 ]; do
         if [ -n "$VERBOSE" ]; then
-            echo "Ping..."
+            echo "Ping..." 1>&2
         fi
 
         # Prepare and send a ping message
@@ -121,13 +121,13 @@ waitwebsocket() {
         STATUS="`echo -n "$MSG" | websocketcommand`"
         if [ "$STATUS" = "$MSG" ]; then
             if [ -n "$VERBOSE" ]; then
-                echo "OK!"
+                echo "OK!" 1>&2
             fi
             return 0
         fi
 
         if [ -n "$VERBOSE" ]; then
-            echo "$STATUS"
+            echo "$STATUS" 1>&2
         fi
 
         sleep 1
@@ -151,48 +151,44 @@ if ! flock -n 3; then
 fi
 
 addtrap "echo -n > '$PIDFILE' 2>/dev/null"
-PID="$$"
 
-# croutoncycle sends SIGUSR1 to us when needed.
-# We do not care about receiving every single display change in close
-# succession, and we are able to filter out duplicate notifications. On the
-# other hand, we need to make sure the display in $current is the actual one
-# before we start waiting again: The variable SIG catches further display
-# changes while we are transfering the clipboard content.
+(
+    # This subshell handles USR1 signals from croutoncycle.
+    # It prints a line when it receives a signal, or on VT change (we are able
+    # to filter out duplicate notifications).
 
-# Force an update when started.
-SIG='force'
-trap "SIG='USR1'" USR1
-
-# Set the PID after the trap is in place
-echo -n "$PID" > "$PIDFILE"
-
-# Send signal on VT change (if user types Ctrl-Alt instead of Ctrl-Alt-Shift)
-if hash croutonvtmonitor 2>/dev/null; then
-    ( croutonvtmonitor | while read line; do kill -USR1 "$PID"; done ) &
+    # Start croutonwebsocket here to give "wait" something to wait for
+    croutonwebsocket &
     addtrap "kill $! 2>/dev/null"
-fi
 
-croutonwebsocket &
-addtrap "kill $! 2>/dev/null"
+    waitwebsocket
 
-waitwebsocket
-
-while true; do
-    if [ -z "$SIG" ]; then
-        # Block until a signal is received: we have at least one child, so we
-        # just wait on any of them.
-        # Wait returns an error when interrupted by a signal.
-        if wait; then
-            # No more children, bailing out to avoid busy-looping.
-            exit 1
-        fi
+    # Update on VT change (if user types Ctrl-Alt instead of Ctrl-Alt-Shift)	
+    if hash croutonvtmonitor 2>/dev/null; then
+       croutonvtmonitor &
+       addtrap "kill $! 2>/dev/null"
     fi
-    # This is _not_ a potential race: the current display is read after this.
-    SIG=''
 
-    display="`croutoncycle display`"
-    copyclip "$display"
-done
+    trap "echo 'USR1'" USR1
+
+    # Set the PID of this subshell after the trap is in place
+    sh -c 'echo -n "$PPID"' > "$PIDFILE"
+
+    # Force an update when started.
+    echo "Force"
+
+    # Wait until all the children have terminated (gets interrupted on signal,
+    # which gives handlers a chance to run)
+    while ! wait; do
+        :
+    done
+) | (
+    # Do not hold the lock in this subshell and children (especially xclip)
+    exec 3>/dev/null
+    while read line; do
+        display="`croutoncycle display`"
+        copyclip "$display"
+    done
+)
 
 exit 1


### PR DESCRIPTION
`croutonclip` was broken on Arch (bash 4.3.24), and trusty, when using bash 4.3.11 (uncommon, as dash is the default), due to a change in signal handling in `read` (basically `read` would not get interrupted by signals...).

The first commit attempted to fix this, and worked well on Arch, but segfaulted on trusty/bash.

Ended-up refactoring the code (second commit), the result is, overall, a bit cleaner and simpler.

Tested on falco:
- arch bash 4.3.24
- trusty bash 4.3.11 / dash
- precise bash 4.2.25 / dash (Xephyr)
