### PR TITLE
ubuntu/bootstrap: Patch debootstrap so that it retries downloads

### DIFF
--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -32,17 +32,23 @@ Check your internet connection or proxy settings and try again.'
 fi
 
 # Patch debootstrap so that it retries downloading packages
-awk '
-    t == 2 && /-z \"\$checksum\"/ { sub(/\$checksum/, "$checksum$failed"); t=0 }
-    t == 1 { sub(/if \[/, "elif ["); t=2 }
+echo 'Patching debootstrap...' 1>&2
+if awk '
+    t == 2 && /-z \"\$checksum\"/ { sub(/\$checksum/, "$checksum$failed"); t=3 }
+    t == 1 { if (/if \[/) { sub(/if \[/, "elif ["); t=2 } else { exit 1 } }
     /if ! just_get \"\$from\" \"\$dest2\"; then continue 2; fi/ {
         sub(/if !/, "failed=; if !")
         sub(/continue 2; fi/, "failed=y")
         t=1
     }
     1
-' "$tmp/functions" > "$tmp/functions.new"
-mv -f "$tmp/functions.new" "$tmp/functions"
+    END { if (t != 3) exit 1 }
+        ' "$tmp/functions" > "$tmp/functions.new"; then
+    mv -f "$tmp/functions.new" "$tmp/functions"
+else
+    rm -f "$tmp/functions.new"
+    echo "Unable to patch debootstrap, moving on..." 1>&2
+fi
 
 # Add the necessary debootstrap executables
 newpath="$PATH:$tmp"


### PR DESCRIPTION
It retries 10 times, which is arguably too many times, but that should be better than the current behaviour (try once).

Applies cleanly on git HEAD and debootstrap 1.0.61. I will try to upstream that modification.

Test:
- Start installer, regularly run `sudo pkill wget` and check that the installation still proceeds.

Base case (no error, we don't have fault injection (yet)) tested in `2014-09-07_20-18-15_drinkcat_chroagh_deboostrap-retry_10`.

Fixes #1018.
