### PR TITLE
edit-chroot: sync filesystem after backup is completed

### DIFF
--- a/host-bin/edit-chroot
+++ b/host-bin/edit-chroot
@@ -343,6 +343,8 @@ for NAME in "$@"; do
             echo "Unable to backup $CHROOT." 1>&2
             exit $ret
         fi
+        # Make sure filesystem is sync'ed
+        sync
         undotrap
         echo "Finished backing up $CHROOT to $dest" 1>&2
     fi
@@ -383,6 +385,8 @@ for NAME in "$@"; do
         mkdir -p "$CHROOT"
         spinner 1 tar --checkpoint=200 --checkpoint-action=exec=echo \
             --one-file-system -xaf "$src" -C "$CHROOT" --strip-components=1
+        # Make sure filesystem is sync'ed
+        sync
         echo "Finished restoring $src to $CHROOT" 1>&2
     fi
 


### PR DESCRIPTION
Make sure that the data is actually on the physical device.

Just seen a suspicious case, where it appears that the archive (on a NTFS device) was truncated.

Do it on backup (most critical) and restore (probably less critical, but does not hurt).
