### PR TITLE
audio: Relax matching rules for sbc package on wheezy

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -231,9 +231,9 @@ build_cras() {
     elif release -le wheezy -eq kali; then
         # wheezy provides a backport for libsbc1
         install_mirror_package 'libsbc1' \
-                            'pool/main/s/sbc' '.*~bpo7\+.*' $cras_arch
+                            'pool/main/s/sbc' '.*~bpo7.*' $cras_arch
         install_mirror_package --asdeps 'libsbc-dev' \
-                            'pool/main/s/sbc' '.*~bpo7\+.*' $cras_arch
+                            'pool/main/s/sbc' '.*~bpo7.*' $cras_arch
     else
         install --minimal libsbc1$pkgsuffix
         install --minimal --asdeps libsbc-dev$pkgsuffix


### PR DESCRIPTION
Some mirrors escape `+` as `%2b` in the URL, which causes the regex not to match. Relax the regex so that we do not match the `+` (that was probably overcautious in the first place).

Fixes #1043.
