### PR TITLE
indirect installer: Use curl instead of wget

### DIFF
--- a/installer/crouton
+++ b/installer/crouton
@@ -39,7 +39,7 @@ set -e
 
 CROUTON_BRANCH="${CROUTON_BRANCH#master}"
 INSTALLER="crouton${CROUTON_BRANCH:+-}${CROUTON_BRANCH:-}"
-URL="https://raw.githubusercontent.com/dnschneid/crouton/releases/$INSTALLER"
+URL="https://github.com/dnschneid/crouton/raw/releases/$INSTALLER"
 CACHEDIR="/tmp/${0##*/}-installer-cache"
 CACHEFILE="$CACHEDIR/$INSTALLER"
 MAXAGE="$((30*60))"
@@ -59,7 +59,8 @@ if [ ! -s "$CACHEFILE" -o ! "$CACHEFILE" -nt "$0" ] || \
         echo "Downloading latest $INSTALLER installer..." 1>&2
         trap "rm -f '$CACHEFILE'; exit 1" INT HUP TERM 0
         if ! (umask 022; \
-                curl -s --max-time 60 --retry 2 "$URL" -o "$CACHEFILE"); then
+                curl -# -L --connect-timeout 60 --max-time 300 --retry 2 \
+                    "$URL" -o "$CACHEFILE"); then
             echo "Failed to download $INSTALLER installer.
 Check your internet connection or proxy settings (-P) and try again." 1>&2
             exit 1


### PR DESCRIPTION
wget 1.12 on Chromium OS < 5116 (R33) is buggy and not able to fetch the latest installer.

Also, use direct URL as curl does not follow redirections.

Fixes #1033 for good, so we can leave the version check in the main installer.
