### PR TITLE
audio: Select CRAS version based on commit id from --version

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -263,6 +263,9 @@ mkdir -p "$CHROOT/var/host"
 # Copy in the current Chromium OS version for reference
 cp -f '/etc/lsb-release' "$CHROOT/var/host/"
 
+# Copy CRAS version into the chroot
+cras_test_client --version 2>/dev/null > "$CHROOT/var/host/cras-version" || true
+
 # Copy the latest Xauthority into the chroot
 if [ -f "${XAUTHORITY:=/home/chronos/.Xauthority}" ]; then
     cp -f "$XAUTHORITY" "$CHROOT/var/host/Xauthority"

--- a/targets/audio
+++ b/targets/audio
@@ -19,16 +19,27 @@ addtrap "rm -rf --one-file-system '$CRASBUILDTMP'"
 # target sourced before this one (used for automated testing)
 # The custom target also needs to set CROS_VER_1
 if [ -z "$ADHD_HEAD" ]; then
-    # Fetch list of branches from repository
-    wget -O "$CRASBUILDTMP/adhd.refs" \
-'https://chromium.googlesource.com/chromiumos/third_party/adhd/+refs/heads?format=TEXT'
-
     # Chrome OS version (e.g. 4100.86.0)
     CROS_VER="`sed -n 's/^CHROMEOS_RELEASE_VERSION=//p' /var/host/lsb-release`"
 
     # Set CROS_VER_1 to the major version number (e.g. 4100), used later on to
     # selectively apply patches.
     CROS_VER_1="${CROS_VER%%.*}"
+
+    cras_version="`cat /var/host/cras-version 2>/dev/null || true`"
+    ADHD_HEAD="${cras_version##*-}"
+    # Make sure ADHD_HEAD looks like a commit id
+    if [ "${#ADHD_HEAD}" -ne 40 -o "${head%[^0-9a-f]*}" != "$head" ]; then
+        echo "Empty or invalid cras-version (${cras_version})." 1>&2
+        ADHD_HEAD=""
+    fi
+fi
+
+# TODO: Remove autodetection code (not needed since build 6276)
+if [ -z "$ADHD_HEAD" ]; then
+    # Fetch list of branches from repository
+    wget -O "$CRASBUILDTMP/adhd.refs" \
+'https://chromium.googlesource.com/chromiumos/third_party/adhd/+refs/heads?format=TEXT'
 
     echo "Detecting CRAS branch (Chromium OS build $CROS_VER)..." 1>&2
 
@@ -250,6 +261,9 @@ build_cras() {
         tar -xmf adhd.tar.gz cras/src
 
         cd cras/src
+
+        # Create version file
+        echo '#define VCSID "crouton-'"$ADHD_HEAD"'"' > common/cras_version.h
 
         install --minimal --asdeps patch
 


### PR DESCRIPTION
Since http://crbug.com/398796 is fixed, we can now rely on the output of `cras_test_client --version`, when available.

I decided to execute `cras_test_client --version` in `enter-chroot`, instead of doing it in the target file header, so that we can more easily retrieve the version for autoupdates.
