### PR TITLE
installer/prepare: Ignore kbd_mode errors

### DIFF
--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -165,7 +165,7 @@ fixkeyboardmode() {
                 tty='tty1'
             fi
             if [ -e "/dev/$tty" ]; then
-                kbd_mode -s -C "/dev/$tty"
+                kbd_mode -s -C "/dev/$tty" 2>/dev/null || true
             fi
         done
     fi


### PR DESCRIPTION
Sometimes crosh gets killed, leaving Xorg alive, but the `/dev/pts` file is not around anymore.

Without this, the installer fails.
