### PR TITLE
targets/audio: If commit id is not found, fall back on master

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -105,7 +105,7 @@ archive="$CRASBUILDTMP/adhd.tar.gz"
 urlbase="https://chromium.googlesource.com/chromiumos/third_party/adhd/+archive"
 if ! wget --content-on-error -O "$archive" "$urlbase/$ADHD_HEAD.tar.gz"; then
     if grep -q "Error 404" "$archive" 2>/dev/null; then
-        echo "Branch not found, falling back on master..." 1>&2
+        echo "Branch not found, falling back on master (audio might not work)..." 1>&2
         ADHD_HEAD="master"
         wget -O "$archive" "$urlbase/$ADHD_HEAD.tar.gz"
     else


### PR DESCRIPTION
Can happen with developer builds using prebuilt packages, see http://crbug.com/417820.

In this case, we assume that the developer will update the machine frequently and using `master` is appropriate.
