### PR TITLE
Replacing http://goo.gl links with https://goo.gl links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ crouton is a powerful tool, and there are a *lot* of features, but basic usage
 is as simple as possible by design.
 
 If you're just here to use crouton, you can grab the latest release from
-[goo.gl/fd3zc](http://goo.gl/fd3zc). Download it, pop open a shell
+[https://goo.gl/fd3zc](https://goo.gl/fd3zc). Download it, pop open a shell
 (Ctrl+Alt+T, type `shell` and hit enter), and run `sh ~/Downloads/crouton` to
 see the help text. See the "examples" section for some usage examples.
 
@@ -116,7 +116,7 @@ Examples
      command-line tools using `-t core` or `-t cli-extra`
   2. Enter the chroot in as many crosh shells as you want simultaneously using
      `sudo enter-chroot`
-  3. Use the [Crosh Window](http://goo.gl/eczLT) extension to keep Chromium OS
+  3. Use the [Crosh Window](https://goo.gl/eczLT) extension to keep Chromium OS
      from eating standard keyboard shortcuts.
 
 ### A new version of crouton came out; my chroot is therefore obsolete and sad

--- a/host-ext/crouton/first.html
+++ b/host-ext/crouton/first.html
@@ -27,7 +27,7 @@
     <hr style="margin-bottom: 1em; clear:both;"/>
     <div class="text">Thank you for installing the crouton extension!</div>
     <div class="text">This extension provides clipboard synchronization and URL handler to <a href="https://github.com/dnschneid/crouton">crouton</a> chroots.</div>
-    <div class="text">If you have not done so yet, you should download the <a href="http://goo.gl/fd3zc">crouton installer</a>.</div>
+    <div class="text">If you have not done so yet, you should download the <a href="https://goo.gl/fd3zc">crouton installer</a>.</div>
     <div class="text">Then follow instructions in the <a href="https://github.com/dnschneid/crouton/blob/master/README.md">README</a> to get your first chroot running.</div>
     <div class="text">Be sure to install the <em>extension</em> target with the chroot.</div>
     <div class="text">Need more help? Check out the <a href="https://github.com/dnschneid/crouton/wiki">wiki</a>!</div>

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -138,7 +138,7 @@ if ! awk -F= '/_RELEASE_VERSION=/ { exit int($2) < '"${CROS_MIN_VERS:-0}"' }' \
 If there are updates pending, please reboot and try again.
 Otherwise, you may not be getting automatic updates, in which case you should
 post your update_engine.log from chrome://system to http://crbug.com/296768 and
-restore your device using a recovery USB: http://goo.gl/AZ74hj"
+restore your device using a recovery USB: https://goo.gl/AZ74hj"
 fi
 
 # If the release is "list" or "help", print out all the valid releases.
@@ -495,7 +495,7 @@ You will likely run into issues, but things may work with some effort." 1>&2
     else
         echo "\
 If this is a surprise to you, $RELEASE has probably reached end of life.
-Refer to http://goo.gl/Z5LGVD for upgrade instructions." 1>&2
+Refer to https://goo.gl/Z5LGVD for upgrade instructions." 1>&2
     fi
     sleep 5
 fi

--- a/targets/extension
+++ b/targets/extension
@@ -43,6 +43,6 @@ You already have the Chromium OS extension installed, so you're good to go!
 else
     TIPS="$TIPS
 You must install the Chromium OS extension for integration with crouton to work.
-The extension is available here: http://goo.gl/OVQOEt
+The extension is available here: https://goo.gl/OVQOEt
 "
 fi


### PR DESCRIPTION
If you wget or curl the http://goo.gl links, like the instructions say, a man-in-the-middle attacker could hijack that  request and redirect to it a malicious version of crouton, e.g. one that installs a rootkit after installing Linux. But the goo.gl service supports and works fine with https, so there's no reason not to tell people to use that instead.
