### PR TITLE
enter-chroot: Remap devbroker-access group.

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -415,8 +415,8 @@ fi
 # so that users have access to shared hardware, such as video and audio.
 gfile="$CHROOT/etc/group"
 if [ -f "$gfile" ]; then
-    for group in audio:hwaudio cras:audio cdrom disk floppy i2c input lp \
-                 serial tape tty usb:plugdev uucp video; do
+    for group in audio:hwaudio cras:audio cdrom devbroker-access disk floppy \
+                 i2c input lp serial tape tty usb:plugdev uucp video; do
         hostgroup="${group%:*}"
         chrootgroup="${group#*:}"
         gid="`awk -F: '$1=="'"$hostgroup"'"{print $3; exit}' '/etc/group'`"


### PR DESCRIPTION
Enables security key users to add themselves to the group, and/or add custom udev rules.

I do not want to add the user to the group by default, as I'm not sure of the security implication, and security keys usage in Chrome/ium inside crouton is probably a niche usage.

Partly fixes #1162.
