### PR TITLE
lxde: Do not install wicd (network manager)

### DIFF
--- a/targets/lxde
+++ b/targets/lxde
@@ -8,7 +8,7 @@ HOSTBIN='startlxde'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-install lxde -- dictionaries-common chromium-browser network-manager
+install lxde -- dictionaries-common chromium-browser network-manager wicd
 
 TIPS="$TIPS
 You can start LXDE via the startlxde host command: sudo startlxde


### PR DESCRIPTION
sid pulls it in as recommended dependency, and even shows a dialog on lxde startup...
