### PR TITLE
Clarify creating a chroot with a bootstrap tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Examples
   3. Include the `-r` parameter if you want to specify for which release to
      prepare a bootstrap.
   4. You can then create chroots using the tarball by running
-     `sudo sh ~/Downloads/crouton -f ~/Downloads/mybootstrap.tar.bz2`
+     `sudo sh ~/Downloads/crouton -f ~/Downloads/mybootstrap.tar.bz2`. Make sure 
+      you also specify the target environment with `-t`.
 
 *This is the quickest way to create multiple chroots at once, since you won't
 have to determine and download the bootstrap files every time.*


### PR DESCRIPTION
Clarify that you also need to specify the `-t` parameter after downloading the bootstrap files.

Given that you don't get an error about missing a target when running `-f` without `-t`, it took me quite a while and some googling to figure out why the command in step 4 didn't work; given that it was in the readme and every other command before this didn't need additional parameters, it was surprising that I needed to also add the `-t` parameter. I kind of get the distinction between a bootstrap and a target now that I've done it but I think mentioning it will save someone else from having to figure out what they are doing wrong after literally following the steps in the readme.
