### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 ##For users who want to report an issue
-Please read [this wiki page](https://github.com/dnschneid/crouton/wiki/Common-issues-and-reporting)
+Please read [this wiki page]
+(https://github.com/dnschneid/crouton/wiki/Common-issues-and-reporting)
 for instructions on reporting an issue.
 
 ##For contributors


### PR DESCRIPTION
As I have seen @dnschneid and @drinkcat repeatedly told people to provide the output of `croutonversion` and  sometimes people don't see the wiki and README since they are either hiding too deeply or having too much to read. So I think it would be better to just add this as a notice so people can see when they create issues.
