### PR TITLE
Prioritize targets which PROVIDES

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -686,6 +686,21 @@ else
 fi
 
 echo -n '' > "$TARGETDEDUPFILE"
+# Check if a target has defined PROVIDES, if we are not restoring host-bin.
+if [ ! -n "$RESTOREHOSTBIN" ]; then
+    # Create temporary file to list PROVIDES=TARGET.
+    PROVIDESFILE="`mktemp --tmpdir=/tmp "$APPLICATION-provides.XXX"`"
+    addtrap "rm -f '$PROVIDESFILE'"
+    t="${TARGETS%,},"
+    while [ -n "$t" ]; do
+        TARGET="${t%%,*}"
+        t="${t#*,}"
+        if [ -n "$TARGET" ]; then
+            (TARGETNOINSTALL="p"; . "$TARGETSDIR/$TARGET")
+        fi
+    done
+fi
+
 # Run each target, appending stdout to the prepare script.
 unset SIMULATE
 TARGETNOINSTALL="$RESTOREHOSTBIN"

--- a/targets/common
+++ b/targets/common
@@ -33,17 +33,12 @@ if [ "$TARGETS" = 'help' ]; then
         echo "	Requires: $REQUIRES"
     fi
 elif [ "$TARGETNOINSTALL" = "p" ]; then
-    # Avoid adding things already provided
-    # This will only check the provides from /etc/crouton/targets
-    # and targets specified with -t.
+    # This will check the provides from /etc/crouton/targets and targets
+    # specified with -t. If there are duplicates we will respect the
+    # order of the targets specified. This means on an update targets
+    # specified with -t will have higher priority then already installed targets.
     for t in $PROVIDES; do
-        # Don't add duplicate PROVIDES. If there are duplicates
-        # we will respect the order of the targets specified.
-        # This means on an update targets specified with -t
-        # will have higher priority then already installed targets.
-        if ! grep -q "^$t=.*\$" "${PROVIDESFILE:-/dev/null}"; then
-            echo "$t=$TARGET" >> "${PROVIDESFILE:-/dev/null}"
-        fi
+        echo "$t=$TARGET" >> "${PROVIDESFILE:-/dev/null}"
     done
 elif [ -z "$TARGETNOINSTALL" -o -n "$RESTOREHOSTBIN" ]; then
     # Avoid double-adding targets
@@ -58,10 +53,9 @@ elif [ -z "$TARGETNOINSTALL" -o -n "$RESTOREHOSTBIN" ]; then
     done
     # Source the prerequisites
     for t in $REQUIRES; do
-	# If it is already provided change it to the target what provides it.
-        if grep -q "^$t=.*\$" "${PROVIDESFILE:-/dev/null}"; then
-            t="`awk -F= '/'$t'=/{print $2}' "${PROVIDESFILE:-/dev/null}"`"
-        fi
+        # If it is already provided change it to the target what provides it.
+        provider="`awk -F= '/'"$t"'=/{print $2; exit}' "${PROVIDESFILE:-/dev/null}"`"
+        t="${provider:-"$t"}"
         (TARGET="$t" PROVIDES='' HOSTBIN='' CHROOTBIN='' CHROOTETC=''
          . "$TARGETSDIR/$t")
     done

--- a/targets/common
+++ b/targets/common
@@ -32,6 +32,19 @@ if [ "$TARGETS" = 'help' ]; then
     if [ -n "$REQUIRES" ]; then
         echo "	Requires: $REQUIRES"
     fi
+elif [ "$TARGETNOINSTALL" = "p" ]; then
+    # Avoid adding things already provided
+    # This will only check the provides from /etc/crouton/targets
+    # and targets specified with -t.
+    for t in $PROVIDES; do
+        # Don't add duplicate PROVIDES. If there are duplicates
+        # we will respect the order of the targets specified.
+        # This means on an update targets specified with -t
+        # will have higher priority then already installed targets.
+        if ! grep -q "^$t=.*\$" "${PROVIDESFILE:-/dev/null}"; then
+            echo "$t=$TARGET" >> "${PROVIDESFILE:-/dev/null}"
+        fi
+    done
 elif [ -z "$TARGETNOINSTALL" -o -n "$RESTOREHOSTBIN" ]; then
     # Avoid double-adding targets
     if grep -q "^$TARGET\$" "${TARGETDEDUPFILE:-/dev/null}"; then
@@ -45,6 +58,10 @@ elif [ -z "$TARGETNOINSTALL" -o -n "$RESTOREHOSTBIN" ]; then
     done
     # Source the prerequisites
     for t in $REQUIRES; do
+	# If it is already provided change it to the target what provides it.
+        if grep -q "^$t=.*\$" "${PROVIDESFILE:-/dev/null}"; then
+            t="`awk -F= '/'$t'=/{print $2}' "${PROVIDESFILE:-/dev/null}"`"
+        fi
         (TARGET="$t" PROVIDES='' HOSTBIN='' CHROOTBIN='' CHROOTETC=''
          . "$TARGETSDIR/$t")
     done


### PR DESCRIPTION
Regarding https://github.com/dnschneid/crouton/issues/1198
This should for example prevent installing target xorg when xfce, xiwi are targets and xfce is first defined in `-t xfce,xiwi` or xiwi is already installed and you update with xfce. 