### PR TITLE
Kiwi: Send keycodes instead of keysyms

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -129,6 +129,8 @@ fi
 
 # Crouton-in-a-tab: Start fbserver and launch display
 if [ "$XMETHOD" = 'xiwi' ]; then
+    # The extension sends evdev key codes: fix the keyboard mapping rules
+    setxkbmap -rules evdev
     # Set resolution to a default 1024x768, this is important so that the DPI
     # looks reasonable when the WM/DE start.
     setres 1024 768 > /dev/null

--- a/host-ext/nacl_src/keycode_converter.h
+++ b/host-ext/nacl_src/keycode_converter.h
@@ -1,0 +1,215 @@
+/* Copyright (c) 2015 The crouton Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ *
+ * Translates NaCl pp::KeyboardInputEvent::KeyCode() strings to X11 keycodes.
+ */
+
+#include <map>
+#include <string>
+#include <stdint.h>
+
+/* Values in the keycode hashmap. */
+class KeyCode {
+public:
+    KeyCode(uint8_t base, uint8_t search):
+        base_(base), search_(search) {}
+
+    KeyCode(uint8_t base): KeyCode(base, base) {}
+
+    uint8_t GetCode(const bool search_on) const {
+        if (search_on)
+            return search_;
+        else
+            return base_;
+    }
+
+private:
+    const uint8_t base_;  /* Basic keycode */
+    /* Reverse translation of keycode when Search is pressed: e.g.
+     * Search+Left => Home. In this case:
+     * base_ = Home keycode (0x6e), search_ = Left keycode (0x71) */
+    const uint8_t search_;
+};
+
+/* Class with static members only: converts KeyCode string to X11 keycode */
+class KeyCodeConverter {
+public:
+    static uint8_t GetCode(const std::string& str, const bool search_on) {
+        if (!strcodemap_)
+            InitMap();
+
+        auto it = strcodemap_->find(str);
+        /* Not found */
+        if (it == strcodemap_->end())
+            return 0;
+
+        return it->second.GetCode(search_on);
+    }
+
+private:
+    static void InitMap();
+    /* static pointer member, to avoid static variable of class type. */
+    static std::map<std::string, const KeyCode>* strcodemap_;
+};
+
+std::map<std::string, const KeyCode>* KeyCodeConverter::strcodemap_ = NULL;
+
+/* Initialize string to X11 keycode mapping. Must be called once only.
+ *
+ * FIXME: Fill in search_ fields in KeyCode.
+ *
+ * Most of this data can be generated from
+ * ui/events/keycodes/dom4/keycode_converter_data.h in the Chromium source
+ * tree, using something like:
+ * sed -n \
+'s/.*USB_KEYMAP([^,]*, \([^,]*\),.*, \("[^"]*"\).*$/{\2, KeyCode(\1)},/p' \
+keycode_converter_data.h | grep -v "0x00" >> keymap_data.h
+ */
+void KeyCodeConverter::InitMap() {
+    strcodemap_ = new std::map<std::string, const KeyCode>({
+        {"Sleep", KeyCode(0x96)},
+        {"WakeUp", KeyCode(0x97)},
+        {"KeyA", KeyCode(0x26)},
+        {"KeyB", KeyCode(0x38)},
+        {"KeyC", KeyCode(0x36)},
+        {"KeyD", KeyCode(0x28)},
+        {"KeyE", KeyCode(0x1a)},
+        {"KeyF", KeyCode(0x29)},
+        {"KeyG", KeyCode(0x2a)},
+        {"KeyH", KeyCode(0x2b)},
+        {"KeyI", KeyCode(0x1f)},
+        {"KeyJ", KeyCode(0x2c)},
+        {"KeyK", KeyCode(0x2d)},
+        {"KeyL", KeyCode(0x2e)},
+        {"KeyM", KeyCode(0x3a)},
+        {"KeyN", KeyCode(0x39)},
+        {"KeyO", KeyCode(0x20)},
+        {"KeyP", KeyCode(0x21)},
+        {"KeyQ", KeyCode(0x18)},
+        {"KeyR", KeyCode(0x1b)},
+        {"KeyS", KeyCode(0x27)},
+        {"KeyT", KeyCode(0x1c)},
+        {"KeyU", KeyCode(0x1e)},
+        {"KeyV", KeyCode(0x37)},
+        {"KeyW", KeyCode(0x19)},
+        {"KeyX", KeyCode(0x35)},
+        {"KeyY", KeyCode(0x1d)},
+        {"KeyZ", KeyCode(0x34)},
+        {"Digit1", KeyCode(0x0a)},
+        {"Digit2", KeyCode(0x0b)},
+        {"Digit3", KeyCode(0x0c)},
+        {"Digit4", KeyCode(0x0d)},
+        {"Digit5", KeyCode(0x0e)},
+        {"Digit6", KeyCode(0x0f)},
+        {"Digit7", KeyCode(0x10)},
+        {"Digit8", KeyCode(0x11)},
+        {"Digit9", KeyCode(0x12)},
+        {"Digit0", KeyCode(0x13)},
+        {"Enter", KeyCode(0x24)},
+        {"Escape", KeyCode(0x09)},
+        {"Backspace", KeyCode(0x16)},
+        {"Tab", KeyCode(0x17)},
+        {"Space", KeyCode(0x41)},
+        {"Minus", KeyCode(0x14)},
+        {"Equal", KeyCode(0x15)},
+        {"BracketLeft", KeyCode(0x22)},
+        {"BracketRight", KeyCode(0x23)},
+        {"Backslash", KeyCode(0x33)},
+        {"IntlHash", KeyCode(0x33)},
+        {"Semicolon", KeyCode(0x2f)},
+        {"Quote", KeyCode(0x30)},
+        {"Backquote", KeyCode(0x31)},
+        {"Comma", KeyCode(0x3b)},
+        {"Period", KeyCode(0x3c)},
+        {"Slash", KeyCode(0x3d)},
+        {"CapsLock", KeyCode(0x42)},
+        {"F1", KeyCode(0x43)},
+        {"F2", KeyCode(0x44)},
+        {"F3", KeyCode(0x45)},
+        {"F4", KeyCode(0x46)},
+        {"F5", KeyCode(0x47)},
+        {"F6", KeyCode(0x48)},
+        {"F7", KeyCode(0x49)},
+        {"F8", KeyCode(0x4a)},
+        {"F9", KeyCode(0x4b)},
+        {"F10", KeyCode(0x4c)},
+        {"F11", KeyCode(0x5f)},
+        {"F12", KeyCode(0x60)},
+        {"PrintScreen", KeyCode(0x6b)},
+        {"ScrollLock", KeyCode(0x4e)},
+        {"Pause", KeyCode(0x7f)},
+        {"Insert", KeyCode(0x76)},
+        {"Home", KeyCode(0x6e)},
+        {"PageUp", KeyCode(0x70)},
+        {"Delete", KeyCode(0x77)},
+        {"End", KeyCode(0x73)},
+        {"PageDown", KeyCode(0x75)},
+        {"ArrowRight", KeyCode(0x72)},
+        {"ArrowLeft", KeyCode(0x71)},
+        {"ArrowDown", KeyCode(0x74)},
+        {"ArrowUp", KeyCode(0x6f)},
+        {"NumLock", KeyCode(0x4d)},
+        {"NumpadDivide", KeyCode(0x6a)},
+        {"NumpadMultiply", KeyCode(0x3f)},
+        {"NumpadSubtract", KeyCode(0x52)},
+        {"NumpadAdd", KeyCode(0x56)},
+        {"NumpadEnter", KeyCode(0x68)},
+        {"Numpad1", KeyCode(0x57)},
+        {"Numpad2", KeyCode(0x58)},
+        {"Numpad3", KeyCode(0x59)},
+        {"Numpad4", KeyCode(0x53)},
+        {"Numpad5", KeyCode(0x54)},
+        {"Numpad6", KeyCode(0x55)},
+        {"Numpad7", KeyCode(0x4f)},
+        {"Numpad8", KeyCode(0x50)},
+        {"Numpad9", KeyCode(0x51)},
+        {"Numpad0", KeyCode(0x5a)},
+        {"NumpadDecimal", KeyCode(0x5b)},
+        {"IntlBackslash", KeyCode(0x5e)},
+        {"ContextMenu", KeyCode(0x87)},
+        {"Power", KeyCode(0x7c)},
+        {"NumpadEqual", KeyCode(0x7d)},
+        {"Help", KeyCode(0x92)},
+        {"Again", KeyCode(0x89)},
+        {"Undo", KeyCode(0x8b)},
+        {"Cut", KeyCode(0x91)},
+        {"Copy", KeyCode(0x8d)},
+        {"Paste", KeyCode(0x8f)},
+        {"Find", KeyCode(0x90)},
+        {"VolumeMute", KeyCode(0x79)},
+        {"VolumeUp", KeyCode(0x7b)},
+        {"VolumeDown", KeyCode(0x7a)},
+        {"IntlRo", KeyCode(0x61)},
+        {"KanaMode", KeyCode(0x65)},
+        {"IntlYen", KeyCode(0x84)},
+        {"Convert", KeyCode(0x64)},
+        {"NonConvert", KeyCode(0x66)},
+        {"Lang1", KeyCode(0x82)},
+        {"Lang2", KeyCode(0x83)},
+        {"Lang3", KeyCode(0x62)},
+        {"Lang4", KeyCode(0x63)},
+        {"Abort", KeyCode(0x88)},
+        {"NumpadParenLeft", KeyCode(0xbb)},
+        {"NumpadParenRight", KeyCode(0xbc)},
+        {"ControlLeft", KeyCode(0x25)},
+        {"ShiftLeft", KeyCode(0x32)},
+        {"AltLeft", KeyCode(0x40)},
+        {"OSLeft", KeyCode(0x85)},
+        {"ControlRight", KeyCode(0x69)},
+        {"ShiftRight", KeyCode(0x3e)},
+        {"AltRight", KeyCode(0x6c)},
+        {"OSRight", KeyCode(0x86)},
+        {"BrightnessUp", KeyCode(0xe9)},
+        {"BrightnessDown", KeyCode(0xea)},
+        {"LaunchApp2", KeyCode(0x94)},
+        {"LaunchApp1", KeyCode(0xa5)},
+        {"BrowserBack", KeyCode(0xa6)},
+        {"BrowserForward", KeyCode(0xa7)},
+        {"BrowserRefresh", KeyCode(0xb5)},
+        {"BrowserFavorites", KeyCode(0xa4)},
+        {"MailReply", KeyCode(0xf0)},
+        {"MailForward", KeyCode(0xf1)},
+        {"MailSend", KeyCode(0xef)},
+    });
+}

--- a/host-ext/nacl_src/kiwi.cc
+++ b/host-ext/nacl_src/kiwi.cc
@@ -229,10 +229,22 @@ private:
             LogMessage(-1) << "Got a version while connected?!?";
             return false;
         }
-        if (strcmp(data, VERSION)) {
-            LogMessage(-1) << "Invalid version received (" << data << ").";
-            return false;
+
+        server_version_ = data;
+
+        if (server_version_ != VERSION) {
+            /* TODO: Remove VF1 compatiblity */
+            if (server_version_ == "VF1") {
+                LogMessage(-1) << "Outdated server version ("
+                               <<  server_version_ << ").";
+                /* FIXME: Clearly inform the user that the chroot is outdated. */
+            } else {
+                LogMessage(-1) << "Invalid version received ("
+                               << server_version_ << ").";
+                return false;
+            }
         }
+
         connected_ = true;
         SocketSend(pp::Var("VOK"), false);
         ControlMessage("connected", "Version received");
@@ -452,28 +464,33 @@ public:
             event.GetType() == PP_INPUTEVENT_TYPE_KEYUP) {
             pp::KeyboardInputEvent key_event(event);
 
-            uint32_t keycode = key_event.GetKeyCode();
+            uint32_t jskeycode = key_event.GetKeyCode();
             std::string keystr = key_event.GetCode().AsString();
-            uint32_t keysym = KeyCodeToKeySym(keycode, keystr);
             bool down = event.GetType() == PP_INPUTEVENT_TYPE_KEYDOWN;
 
-            LogMessage(keysym == 0 ? 0 : 1)
+            uint8_t keycode = KeyStrToKeyCode(keystr);
+            /* TODO: Remove VF1 compatibility */
+            uint32_t keysym = 0;
+            if (server_version_ == "VF1")
+                keysym = KeyCodeToKeySym(jskeycode, keystr);
+
+            LogMessage(keycode == 0 ? 0 : 1)
                 << "Key " << (down ? "DOWN" : "UP")
                 << ": C:" << keystr
-                << "/KC:" << std::hex << keycode
-                << "/KS:" << std::hex << keysym
-                << (keysym == 0 ? " (KEY UNKNOWN!)" : "")
+                << ", JSKC:" << std::hex << jskeycode
+                << " => KC:" << std::hex << keycode
+                << (keycode == 0 ? " (KEY UNKNOWN!)" : "")
                 << " searchstate:" << search_state_;
 
-            if (keysym == 0) {
+            if (keycode == 0 && keysym == 0) {
                 return PP_TRUE;
             }
 
-            if (keycode == 183) {  /* Fullscreen => toggle fullscreen */
+            if (jskeycode == 183) {  /* Fullscreen => toggle fullscreen */
                 if (!down)
                     ControlMessage("state", "fullscreen");
                 return PP_TRUE;
-            } else if (keycode == 182) {  /* Page flipper => minimize window */
+            } else if (jskeycode == 182) {  /* Page flipper => minimize window */
                 if (!down)
                     ControlMessage("state", "hide");
                 return PP_TRUE;
@@ -482,43 +499,43 @@ public:
             /* We delay sending Super-L, and only "press" it on mouse clicks and
              * letter keys (a-z). This way, Home (Search+Left) appears without
              * modifiers (instead of Super_L+Home) */
-            /* FIXME: NumpadDecimal is a dirty hack for broken freon,
-               see http://crbug.com/425156 */
-            if (keysym == kSUPER_L && (keystr == "OSLeft" ||
-                                       keystr == "NumpadDecimal")) {
+            if (keystr == "OSLeft") {
                 if (down) {
                     search_state_ = kSearchUpFirst;
                 } else {
                     if (search_state_ == kSearchUpFirst) {
                         /* No other key was pressed: press+release */
-                        SendKey(kSUPER_L, 1);
-                        SendKey(kSUPER_L, 0);
+                        SendSearchKey(1);
+                        SendSearchKey(0);
                     } else if (search_state_ == kSearchDown) {
-                        SendKey(kSUPER_L, 0);
+                        SendSearchKey(0);
                     }
                     search_state_ = kSearchInactive;
                 }
                 return PP_TRUE;  /* Ignore key */
             }
 
-            if (keycode >= 65 && keycode <= 90) {  /* letter */
+            if (jskeycode >= 65 && jskeycode <= 90) {  /* letter */
                 /* Search is active, send Super_L if needed */
                 if (down && (search_state_ == kSearchUpFirst ||
                              search_state_ == kSearchUp)) {
-                    SendKey(kSUPER_L, 1);
+                    SendSearchKey(1);
                     search_state_ = kSearchDown;
                 }
             } else {  /* non-letter */
                 /* Release Super_L if needed */
                 if (search_state_ == kSearchDown) {
-                    SendKey(kSUPER_L, 0);
+                    SendSearchKey(0);
                     search_state_ = kSearchUp;
                 } else if (search_state_ == kSearchUpFirst) {
                     /* Switch from UpFirst to Up */
                     search_state_ = kSearchUp;
                 }
             }
-            SendKey(keysym, down ? 1 : 0);
+            if (server_version_ == "VF1")
+                SendKeySym(keysym, down ? 1 : 0);
+            else
+                SendKeyCode(keycode, down ? 1 : 0);
         } else if (event.GetType() == PP_INPUTEVENT_TYPE_MOUSEDOWN ||
                    event.GetType() == PP_INPUTEVENT_TYPE_MOUSEUP   ||
                    event.GetType() == PP_INPUTEVENT_TYPE_MOUSEMOVE) {
@@ -713,8 +730,13 @@ private:
         }
     }
 
+    uint8_t KeyStrToKeyCode(const std::string& code) {
+        return 1;
+    }
+
     /* Converts "IE"/JavaScript keycode to X11 KeySym.
-     * See http://unixpapa.com/js/key.html */
+     * See http://unixpapa.com/js/key.html
+     * TODO: Drop support for VF1 */
     uint32_t KeyCodeToKeySym(uint32_t keycode, const std::string& code) {
         if (keycode >= 65 && keycode <= 90)  /* A to Z */
             return keycode + 32;
@@ -754,7 +776,7 @@ private:
         case 42:  return 0xff61;  // print screen
         case 45:  return 0xff63;  // insert
         case 46:  return 0xffff;  // delete
-        case 91:  return kSUPER_L; // super
+        case 91:  return 0xffeb;  // super
         case 106: return 0xffaa;  // num multiply
         case 107: return 0xffab;  // num plus
         case 109: return 0xffad;  // num minus
@@ -804,7 +826,7 @@ private:
 
         if (down && (search_state_ == kSearchUpFirst ||
                      search_state_ == kSearchUp)) {
-            SendKey(kSUPER_L, 1);
+            SendSearchKey(1);
             search_state_ = kSearchDown;
         }
 
@@ -820,14 +842,38 @@ private:
         SetTargetFPS(kFullFPS);
     }
 
-    /* Sends a key press */
-    void SendKey(uint32_t keysym, int down) {
+    void SendSearchKey(int down) {
+        /* TODO: Drop support for VF1 */
+        if (server_version_ == "VF1")
+            SendKeySym(0xffeb, down);
+        else
+            SendKeyCode(kSUPER_L, down);
+    }
+
+    /* Sends a keysym (VF1) */
+    /* TODO: Drop support for VF1 */
+    void SendKeySym(uint32_t keysym, int down) {
+        struct key_vf1* k;
+        pp::VarArrayBuffer array_buffer(sizeof(*k));
+        k = static_cast<struct key_vf1*>(array_buffer.Map());
+        k->type = 'K';
+        k->down = down;
+        k->keysym = keysym;
+        array_buffer.Unmap();
+        SocketSend(array_buffer, true);
+
+        /* That means we have focus */
+        SetTargetFPS(kFullFPS);
+    }
+
+    /* Sends a keycode */
+    void SendKeyCode(uint8_t keycode, int down) {
         struct key* k;
         pp::VarArrayBuffer array_buffer(sizeof(*k));
         k = static_cast<struct key*>(array_buffer.Map());
         k->type = 'K';
         k->down = down;
-        k->keysym = keysym;
+        k->keycode = keycode;
         array_buffer.Unmap();
         SocketSend(array_buffer, true);
 
@@ -958,7 +1004,7 @@ private:
 private:
     /* Constants */
     /* SuperL keycode (search key) */
-    const uint32_t kSUPER_L = 0xffeb;
+    const uint8_t kSUPER_L = 123; /* FIXME */
 
     const int kFullFPS = 30;   /* Maximum fps */
     const int kBlurFPS = 5;    /* fps when window is possibly hidden */
@@ -978,6 +1024,7 @@ private:
 
     pp::WebSocket websocket_{this};
     bool connected_ = false;
+    std::string server_version_ = "";
     bool screen_flying_ = false;
     pp::Var receive_var_;
     int target_fps_ = kFullFPS;

--- a/src/fbserver-proto.h
+++ b/src/fbserver-proto.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 
 /* WebSocket constants */
-#define VERSION "VF1"
+#define VERSION "VF2"
 #define PORT_BASE 30010
 
 /* Request for a frame */
@@ -61,6 +61,14 @@ struct  __attribute__((__packed__)) resolution {
 
 /* Press a key */
 struct  __attribute__((__packed__)) key {
+    char type;  /* 'K' */
+    uint8_t down:1;  /* 1: down, 0: up */
+    uint8_t keycode;  /* X11 KeyCode (8-255) */
+};
+
+/* Press a key (compatibility with VF1) */
+/* TODO: Remove support for VF1. */
+struct  __attribute__((__packed__)) key_vf1 {
     char type;  /* 'K' */
     uint8_t down:1;  /* 1: down, 0: up */
     uint32_t keysym;  /* X11 KeySym */

--- a/src/fbserver.c
+++ b/src/fbserver.c
@@ -545,17 +545,12 @@ int main(int argc, char** argv) {
                 if (!check_size(length, sizeof(struct key), "key"))
                     break;
                 struct key* k = (struct key*)buffer;
-                KeyCode kc = XKeysymToKeycode(dpy, k->keysym);
-                log(2, "Key: ks=%04x kc=%04x\n", k->keysym, kc);
-                if (kc != 0) {
-                    XTestFakeKeyEvent(dpy, kc, k->down, CurrentTime);
-                    if (k->down) {
-                        kb_add(KEYBOARD, kc);
-                    } else {
-                        kb_remove(KEYBOARD, kc);
-                    }
+                log(2, "Key: kc=%04x\n", k->keycode);
+                XTestFakeKeyEvent(dpy, k->keycode, k->down, CurrentTime);
+                if (k->down) {
+                    kb_add(KEYBOARD, k->keycode);
                 } else {
-                    error("Invalid keysym %04x.", k->keysym);
+                    kb_remove(KEYBOARD, k->keycode);
                 }
                 break;
             }


### PR DESCRIPTION
This is a partial fix for #1275 (but still much better than current situation, so it can be merged as-is).

The protocol now sends X11 key codes instead of key symbols. Keycodes (mostly) correspond to physical keyboard keys, so that the chroot can translate it, depending on the keyboard layout set in crouton.

For that purpose, I had to update protocol version from VF1 to VF2. The extension is backward compatible, though.

What works:
 - Setting US keyboard in Chromium OS (or any keyboard layout without dead keys), any keyboard layout in crouton should work fine.
 - Extension can connect to old chroot (VF1), in that case keysyms are sent.

What still does not work:
 - Setting a keyboard layout in Chromium OS with dead keys (e.g. US Intl) leads to lost key events (I think it's fixable, as the key code appears when the key is lifted).
 - Basic framework for reverting Search+key mapping is there, if the user wants Search+Left to mean Super+Left and not Home (see #1324). Not implemented yet (we need another configuration check box).

Other things to be implemented in other PR:
 - Warn the user that it is connecting to an old chroot.
 - Eventually, drop support for VF1 (this requires extensive rework of error handling in kiwi)

What I don't think can be fixed:
 - Switching Ctrl/Search/Alt in Chromium OS also results in switched positions in crouton.
 - Search+numbers appears the same as Search+fn keys (F1-F10). I don't think we can distinguish between the 2, to support Super+numbers (see #1324).
