### PR TITLE
Raise Chromium OS notifications from crouton

### DIFF
--- a/chroot-bin/croutonnotify
+++ b/chroot-bin/croutonnotify
@@ -29,7 +29,8 @@ Example JSON data:
   "type": "basic",
   "title": "Primary Title",
   "message": "Primary message to display",
-  "crouton_display": ":1"
+  "crouton_display": ":1",
+  "iconUrl": "data:image/png;base64,<base64 encoded png data>"
 }'
 
 . "$(dirname "$0")/../installer/functions"

--- a/chroot-bin/croutonnotify
+++ b/chroot-bin/croutonnotify
@@ -1,0 +1,83 @@
+#!/bin/sh -e
+# Copyright (c) 2015 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+USAGE="${0##*/} -j
+${0##*/} -t title [-m message] [-d display] [-i id]
+Raises a notification in Chromium OS (requires crouton extension).
+
+When -j is specified, reads JSON data from stdin, in the format required
+by chrome.notifications API, with 2 additional fields, \"crouton_id\" and
+\"crouton_display\", corresponding respectively to the notification id, and the
+display to switch to when the notification is clicked (croutoncycle parameter).
+
+Otherwise, constructs a \"basic\" notification with the requested fields.
+
+Options:
+    -j       Read JSON data from stdin (see example below)
+    -t       Title to display (chrome.notifications field: \"title\")
+    -m       Message to display (chrome.notifications field: \"message\")
+    -d       Display to switch to when the notification is clicked (croutoncycle
+             parameter). Default: Do not switch display.
+    -i       ID to pass to chrome.notifications.create: only the last
+             notification with a given ID is shown.
+             Default: Display a new notification.
+
+Example JSON data:
+"'{
+  "type": "basic",
+  "title": "Primary Title",
+  "message": "Primary message to display",
+  "crouton_display": ":1"
+}'
+
+. "$(dirname "$0")/../installer/functions"
+
+DISPLAY=""
+MESSAGE=""
+TITLE=""
+ID=""
+JSON=""
+
+# Process arguments
+while getopts 'd:i:jm:t:' f; do
+    case "$f" in
+    d) DISPLAY="$OPTARG";;
+    i) ID="$OPTARG";;
+    j) JSON="y";;
+    m) MESSAGE="$OPTARG";;
+    t) TITLE="$OPTARG";;
+    \?) error 2 "$USAGE";;
+    esac
+done
+
+# No extra parameters, -j precludes other parameters, and at least title
+# must be specified (or -j)
+if [ "$#" != "$((OPTIND-1))" ] ||
+        [ "$JSON" = 'y' -a -n "$DISPLAY$ID$MESSAGE$TITLE" ] ||
+        [ -z "$JSON$TITLE" ]; then
+    error 2 "$USAGE"
+fi
+
+JSONDATA=""
+if [ -z "$JSON" ]; then
+    JSONDATA='{
+        "type": "'"basic"'",
+        "title": "'"$TITLE"'",
+        "message": "'"$MESSAGE"'",
+        "crouton_display": "'"$DISPLAY"'",
+        "crouton_id": "'"$ID"'"
+    }'
+fi
+
+STATUS="$({
+    echo -n "N$JSONDATA"
+    if [ "$JSON" = 'y' ]; then
+        cat
+    fi
+} | websocketcommand)"
+
+if [ "$STATUS" != 'NOK' ]; then
+    error 1 "${STATUS#?}"
+fi

--- a/chroot-bin/croutonnotify
+++ b/chroot-bin/croutonnotify
@@ -4,7 +4,7 @@
 # found in the LICENSE file.
 
 USAGE="${0##*/} -j
-${0##*/} -t title [-m message] [-d] [-i id]
+${0##*/} -t title [-m message] [-d] [-i icon] [-I id]
 Raises a notification in Chromium OS (requires crouton extension).
 
 When -j is specified, reads JSON data from stdin, in the format required
@@ -20,7 +20,9 @@ Options:
     -m       Message to display (chrome.notifications field: \"message\")
     -d       Switch to display in environment variable DISPLAY ($DISPLAY) when
              the notification is clicked. Default: Do not switch display.
-    -i       ID to pass to chrome.notifications.create: only the last
+    -i       Small icon to display on the left of the notification
+             (chrome.notifications field: \"iconUrl\")
+    -I       ID to pass to chrome.notifications.create: only the last
              notification with a given ID is shown.
              Default: Display a new notification.
 
@@ -39,13 +41,15 @@ SWITCHDISPLAY=""
 MESSAGE=""
 TITLE=""
 ID=""
+ICON=""
 JSON=""
 
 # Process arguments
-while getopts 'di:jm:t:' f; do
+while getopts 'di:I:jm:t:' f; do
     case "$f" in
     d) SWITCHDISPLAY="$DISPLAY";;
-    i) ID="$OPTARG";;
+    i) ICON="$OPTARG";;
+    I) ID="$OPTARG";;
     j) JSON="y";;
     m) MESSAGE="$OPTARG";;
     t) TITLE="$OPTARG";;
@@ -56,9 +60,13 @@ done
 # No extra parameters, -j precludes other parameters, and at least title
 # must be specified (or -j)
 if [ "$#" != "$((OPTIND-1))" ] ||
-        [ "$JSON" = 'y' -a -n "$SWITCHDISPLAY$ID$MESSAGE$TITLE" ] ||
+        [ "$JSON" = 'y' -a -n "$SWITCHDISPLAY$ICON$ID$MESSAGE$TITLE" ] ||
         [ -z "$JSON$TITLE" ]; then
     error 2 "$USAGE"
+fi
+
+if [ -n "$ICON" ] && [ ! -r "$ICON" -o ! -f "$ICON" ]; then
+    error 2 "Cannot open $ICON."
 fi
 
 # Escape json string (backslash and double quotes)
@@ -66,20 +74,23 @@ json_escape() {
     echo -n "$1" | sed -e 's/\\/\\u005C/g;s/"/\\u0022/g'
 }
 
-JSONDATA=""
-if [ -z "$JSON" ]; then
-    JSONDATA='{
-        "type": "basic",
-        "title": "'"$(json_escape "$TITLE")"'",
-        "message": "'"$(json_escape "$MESSAGE")"'",
-        "crouton_display": "'"$(json_escape "$SWITCHDISPLAY")"'",
-        "crouton_id": "'"$(json_escape "$ID")"'"
-    }'
-fi
-
 STATUS="$({
-    echo -n "N$JSONDATA"
-    if [ "$JSON" = 'y' ]; then
+    echo -n "N"
+    if [ -z "$JSON" ]; then
+        echo -n '{
+            "type": "basic",
+            "title": "'"$(json_escape "$TITLE")"'",
+            "message": "'"$(json_escape "$MESSAGE")"'",
+            "crouton_display": "'"$(json_escape "$SWITCHDISPLAY")"'",
+            "crouton_id": "'"$(json_escape "$ID")"'"'
+        if [ -n "$ICON" ]; then
+            ext="${ICON##*.}"
+            echo -n ', "iconUrl": "data:image/'"${ext:-png}"';base64,'
+            base64 -w 0 "$ICON"
+            echo -n '"'
+        fi
+        echo -n '}'
+    else
         cat
     fi
 } | websocketcommand)"

--- a/chroot-bin/croutonnotify
+++ b/chroot-bin/croutonnotify
@@ -60,14 +60,19 @@ if [ "$#" != "$((OPTIND-1))" ] ||
     error 2 "$USAGE"
 fi
 
+# Escape json string (backslash and double quotes)
+json_escape() {
+    echo -n "$1" | sed -e 's/\\/\\u005C/g;s/"/\\u0022/g'
+}
+
 JSONDATA=""
 if [ -z "$JSON" ]; then
     JSONDATA='{
-        "type": "'"basic"'",
-        "title": "'"$TITLE"'",
-        "message": "'"$MESSAGE"'",
-        "crouton_display": "'"$SWITCHDISPLAY"'",
-        "crouton_id": "'"$ID"'"
+        "type": "basic",
+        "title": "'"$(json_escape "$TITLE")"'",
+        "message": "'"$(json_escape "$MESSAGE")"'",
+        "crouton_display": "'"$(json_escape "$SWITCHDISPLAY")"'",
+        "crouton_id": "'"$(json_escape "$ID")"'"
     }'
 fi
 

--- a/chroot-bin/croutonnotify
+++ b/chroot-bin/croutonnotify
@@ -4,7 +4,7 @@
 # found in the LICENSE file.
 
 USAGE="${0##*/} -j
-${0##*/} -t title [-m message] [-d display] [-i id]
+${0##*/} -t title [-m message] [-d] [-i id]
 Raises a notification in Chromium OS (requires crouton extension).
 
 When -j is specified, reads JSON data from stdin, in the format required
@@ -18,8 +18,8 @@ Options:
     -j       Read JSON data from stdin (see example below)
     -t       Title to display (chrome.notifications field: \"title\")
     -m       Message to display (chrome.notifications field: \"message\")
-    -d       Display to switch to when the notification is clicked (croutoncycle
-             parameter). Default: Do not switch display.
+    -d       Switch to display in environment variable DISPLAY ($DISPLAY) when
+             the notification is clicked. Default: Do not switch display.
     -i       ID to pass to chrome.notifications.create: only the last
              notification with a given ID is shown.
              Default: Display a new notification.
@@ -34,16 +34,16 @@ Example JSON data:
 
 . "$(dirname "$0")/../installer/functions"
 
-DISPLAY=""
+SWITCHDISPLAY=""
 MESSAGE=""
 TITLE=""
 ID=""
 JSON=""
 
 # Process arguments
-while getopts 'd:i:jm:t:' f; do
+while getopts 'di:jm:t:' f; do
     case "$f" in
-    d) DISPLAY="$OPTARG";;
+    d) SWITCHDISPLAY="$DISPLAY";;
     i) ID="$OPTARG";;
     j) JSON="y";;
     m) MESSAGE="$OPTARG";;
@@ -55,7 +55,7 @@ done
 # No extra parameters, -j precludes other parameters, and at least title
 # must be specified (or -j)
 if [ "$#" != "$((OPTIND-1))" ] ||
-        [ "$JSON" = 'y' -a -n "$DISPLAY$ID$MESSAGE$TITLE" ] ||
+        [ "$JSON" = 'y' -a -n "$SWITCHDISPLAY$ID$MESSAGE$TITLE" ] ||
         [ -z "$JSON$TITLE" ]; then
     error 2 "$USAGE"
 fi
@@ -66,7 +66,7 @@ if [ -z "$JSON" ]; then
         "type": "'"basic"'",
         "title": "'"$TITLE"'",
         "message": "'"$MESSAGE"'",
-        "crouton_display": "'"$DISPLAY"'",
+        "crouton_display": "'"$SWITCHDISPLAY"'",
         "crouton_id": "'"$ID"'"
     }'
 fi

--- a/host-ext/crouton/manifest.json
+++ b/host-ext/crouton/manifest.json
@@ -25,6 +25,7 @@
   "permissions": [
     "clipboardRead",
     "clipboardWrite",
+    "notifications",
     "tabs"
   ]
 }

--- a/targets/extension
+++ b/targets/extension
@@ -4,7 +4,7 @@
 # found in the LICENSE file.
 REQUIRES='x11'
 DESCRIPTION='Clipboard synchronization and URL handling with Chromium OS.'
-CHROOTBIN='croutonclip croutonurlhandler'
+CHROOTBIN='croutonclip croutonnotify croutonurlhandler'
 EXTENSION='gcpneefbbnfalgjniomfjknbcgkbijom'
 
 # Check if the extension is installed and add a mark to the preparation script


### PR DESCRIPTION
Creates a new message type, "N", that can be sent from `croutonnotify`. It is a JSON-formatted map, compatible with
`chrome.notifications` option format (see https://developer.chrome.com/apps/notifications), with 2 additional fields:
 - `crouton_id`: The notification ID to pass to `chrome.notifications.create`.
 - `crouton_display`: The display to switch to when the notification is clicked.

This  (partially) fixes #581. Integrating notifications nicely with `libnotify` will be more tricky, I guess.

---

As often, while adding new features, I uncovered a bug in the handling of requests coming from the extension:

Requests from the extension can happen at any time, even between a command and its acknowledgement.

Clarified protocol in https://github.com/dnschneid/crouton/wiki/crouton-extension:-websocket-architecture
We now enforce that requests in the form `?<payload>` must have a reply in the form `?<reply>` (where `?` is the same character), or an error reply `E<error>`. (This is already the case, so no protocol change is required)

Test: Start a Kiwi window, and run:
```
for i in `seq 1 1000`; do croutonnotify -i abcd -m t$i; done
```
Even when switching rapidly between Kiwi and Chromium, the command should never print anything (without this patch, it would show `scros` or `s:1` before repeating `Error: Not connected`), and the extension does not disconnect.