### PR TITLE
enter-chroot: Do not fail if /var/run/cras does not exist

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -352,7 +352,6 @@ tmpfsmount /var/run 'noexec,nosuid,mode=0755,size=10%'
 tmpfsmount /var/run/lock 'noexec,nosuid,nodev,size=5120k'
 bindmount /var/run/dbus /var/host/dbus
 bindmount /var/run/shill /var/host/shill
-bindmount /var/run/cras /var/host/cras
 bindmount /var/lib/timezone /var/host/timezone
 for m in /lib/modules/*; do
     if [ -d "$m" ]; then
@@ -373,8 +372,14 @@ else
     ln -sfT /dev/.udev "`fixabslinks '/var/run'`/udev"
 fi
 
-# Add a /var/host/cras symlink for CRAS clients
-ln -sfT /var/host/cras "`fixabslinks '/var/run'`/cras"
+if [ -d /var/run/cras ]; then
+    bindmount /var/run/cras /var/host/cras
+    # Add a /var/host/cras symlink for CRAS clients
+    ln -sfT /var/host/cras "$(fixabslinks '/var/run')/cras"
+else
+    echo "\
+WARNING: CRAS control directory not found, audio forwarding will not work." 1>&2
+fi
 
 # Bind-mount /media, specifically the removable directory
 destmedia="`fixabslinks '/var/host/media'`"

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -378,7 +378,7 @@ if [ -d /var/run/cras ]; then
     ln -sfT /var/host/cras "$(fixabslinks '/var/run')/cras"
 else
     echo "\
-WARNING: CRAS control directory not found, audio forwarding will not work." 1>&2
+WARNING: CRAS not running in Chromium OS. Audio forwarding will not work." 1>&2
 fi
 
 # Bind-mount /media, specifically the removable directory


### PR DESCRIPTION
Fixes #1340.

Test: `sudo mv /var/run/cras /var/run/cras2; sudo enter-chroot` only prints a warning, and does not fail.