### PR TITLE
croutonfindnacl: Match Chromium shm as well.

### DIFF
--- a/chroot-bin/croutonfindnacl
+++ b/chroot-bin/croutonfindnacl
@@ -42,7 +42,8 @@ for pid in $PIDS; do
     [ -n "$VERBOSE" ] && echo "pid:$pid" 1>&2
     # Find candidate mappings
     file="`awk '$1 ~ /^[0-9a-f]*'"$ADDRESS"'-/ && $2 == "rw-s" \
-             && $6 ~ /\/shm\/.com.google.Chrome/ { print $6 }
+             && $6 ~ /\/shm\/\.(com\.google\.Chrome|org\.chromium\.Chromium)/ \
+                   { print $6 }
     ' "/proc/$pid/maps"`"
     [ -n "$VERBOSE" ] && echo "file:$file" 1>&2
     if [ -z "$file" ]; then


### PR DESCRIPTION
Necessary for Chromium OS builds, fixes #1376.