### PR TITLE
autotest: Remove hack to download crouton autotest

### DIFF
--- a/test/autotest_control.template
+++ b/test/autotest_control.template
@@ -25,13 +25,6 @@ This test fetches a specific branch of crouton, and runs crouton tests.
 # For debugging purpose
 utils.system('cat /etc/lsb-release')
 
-# Add repository so that the test tarball can be fetched
-# FIXME: Remove this hack when test is merged
-devserver_url = 'http://172.19.140.1:8082'
-testcsum = """###TESTCSUM###"""
-utils.system("curl '" + devserver_url + "/stage?archive_url=gs://drinkcat-crouton/crouton-test/packages-" + testcsum + "&files=packages.checksum,test-platform_Crouton.tar.bz2'")
-job.add_repository([devserver_url + "/static/crouton-test/packages-" + testcsum])
-
 args_dict = {
           'repo': """###REPO###""",
           'branch': """###BRANCH###""",

--- a/test/daemon.sh
+++ b/test/daemon.sh
@@ -38,9 +38,6 @@ MIRRORENV=""
 # Maximum test run time (minutes): 24 hours
 MAXTESTRUNTIME="$((24*60))"
 GSAUTOTEST="gs://chromeos-autotest-results"
-# FIXME: Remove this when test is merged (>=R39): a temporary hack fetches
-# the crouton test from gs://drinkcat-crouton/crouton-test/packages
-TESTCSUM="811e9713f6357ee3996cb7cce80a3e2b"
 
 USAGE="$APPLICATION [options] -q QUEUEURL
 
@@ -373,7 +370,6 @@ while sleep "$POLLINTERVAL"; do
                         -e "s|###BRANCH###|$branch|" \
                         -e "s|###RUNARGS###|$params|" \
                         -e "s|###ENV###|$MIRRORENV|" \
-                        -e "s|###TESTCSUM###|$TESTCSUM|" \
                         $SCRIPTDIR/test/autotest_control.template \
                         > "$curtesthostroot/control"
 


### PR DESCRIPTION
crouton autotest files are now included in test images, making this irrelevant.