### PR TITLE
Add support in croutoncycle for multiple displays

### DIFF
--- a/chroot-bin/croutoncycle
+++ b/chroot-bin/croutoncycle
@@ -103,7 +103,7 @@ if host-x11 true 2>/dev/null; then
     winlist="`host-x11 croutonwmtools list nim | \
               sort | awk '{ printf $NF " " }'`"
     aurawin="`host-x11 croutonwmtools list ni | \
-              awk '$1 == "aura_root_0" { print $NF; exit }'`"
+              awk '$1 ~ /aura_root_/ { printf $NF " " }'`"
     tty="`cat '/sys/class/tty/tty0/active'`"
 else
     # No X11 server
@@ -123,7 +123,7 @@ if [ "$tty" = 'tty1' ]; then
     for disp in $winlist; do
         if [ "${disp%"*"}" != "$disp" ]; then
             curdisp="$disp"
-            if [ -n "$xiwiactive" -a "${disp%"*"}" = "$aurawin" -a \
+            if [ -n "$xiwiactive" -a "$aurawin" != "${aurawin%${curdisp%"*"}*}" -a \
                     -s "$CRIATDISPLAY" ]; then
                 kiwidisp="`cat $CRIATDISPLAY`"
                 if [ "${kiwidisp#:[0-9]}" != "$kiwidisp" ]; then
@@ -176,7 +176,7 @@ if [ "$cmd" = 'l' -o "$cmd" = 'd' ]; then
         if [ "$disp" = "$curdisp" ]; then
             active='*'
             if [ "$cmd" = 'd' ]; then
-                if [ "$line" = 'aura_root_0' ]; then
+                if [ "${line%?}" = 'aura_root_' ]; then
                     echo 'cros'
                 else
                     echo ":$number"
@@ -185,7 +185,7 @@ if [ "$cmd" = 'l' -o "$cmd" = 'd' ]; then
                 break
             fi
         fi
-        if [ "$line" = 'aura_root_0' ]; then
+        if [ "${line%?}" = 'aura_root_' ]; then
             line="$chromiumos"
             disp="cros"
             window=''
@@ -279,7 +279,7 @@ if [ "${destdisp#:}" = "$destdisp" ]; then
         croutonwmtools raise "${destdisp%"*"}"
     fi
 
-    if [ -n "$xiwiactive" -a "${destdisp%"*"}" = "$aurawin" ]; then
+    if [ -n "$xiwiactive" -a "$aurawin" != "${aurawin%${destdisp%"*"}*}" ]; then
         STATUS="`echo -n "Xcros" | websocketcommand`"
         if [ "$STATUS" != 'XOK' ]; then
             error 1 "${STATUS#?}"


### PR DESCRIPTION
Under xiwi copy and paste wasn't working properly because
the second display was showing up as aura_root_x as well as the
normal aura_root_0.  This makes a few changes necessary to handle
any aura_root_ root window as type cros.