### PR TITLE
extension: Test for view.document.readyState instead of document.readyState.

### DIFF
--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -146,7 +146,7 @@ function refreshUI() {
     for (var i = 0; i < views.length; views++) {
         var view = views[i];
         /* Make sure page is ready */
-        if (document.readyState === "complete") {
+        if (view.document.readyState === "complete") {
             /* Update "help" link */
             helplink = view.document.getElementById("help");
             helplink.onclick = showHelp;

--- a/host-ext/crouton/manifest.json
+++ b/host-ext/crouton/manifest.json
@@ -4,7 +4,7 @@
   "name": "crouton integration",
   "short_name": "crouton",
   "description": "Improves integration with crouton chroots.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "icons": {
     "48": "icon-48.png",
     "128": "icon-128.png"


### PR DESCRIPTION
`document` is the background page, `view.document` is the popup.

Should fix #1510 (I was not able to reproduce, so I'm shooting in the dark).