### PR TITLE
xiwi -f parameter to handle forking programs

### DIFF
--- a/chroot-bin/xiwi
+++ b/chroot-bin/xiwi
@@ -17,7 +17,7 @@ xiwi will normally close when the application returns. Some gui applications
 fork before or during normal operation, which can confuse xiwi and cause it to
 quit prematurely. If your application does not have a parameter that prevents
 it from forking, you can use -f to prevent xiwi from quitting automatically.
-You will need to Ctrl-C xiwi in the terminal to make it quit.
+xiwi will quit if you close the Chromium OS window when nothing is displayed.
 
 A default window manager will full-screen all windows, unless APPLICATION begins
 with 'start'. You can cycle through multiple windows inside the application via
@@ -27,9 +27,9 @@ manager, specify the full path of the application." 1>&2
     exit 2
 elif [ "$1" = '/' ]; then
     shift 1
-    forever='0'
+    foreground=''
     if [ "$1" = '-f' ]; then
-        forever='infinity'
+        foreground="y"
         shift 1
     fi
     xsetroot -cursor_name left_ptr
@@ -38,6 +38,8 @@ elif [ "$1" = '/' ]; then
         # Wait for i3 to launch
         xprop -spy -root | grep -q _NET_ACTIVE_WINDOW
         # Launch the window title monitoring daemon
+        # _NET_ACTIVE_WINDOW is more reliable than _NET_CLIENT_LIST_STACKING for
+        # keeping track of the topmost window.
         xprop -spy -notype -root 0i ' $0\n' '_NET_ACTIVE_WINDOW' 2>/dev/null | {
             name="`cat /etc/crouton/name`"
             monpid=''
@@ -73,7 +75,21 @@ elif [ "$1" = '/' ]; then
         fi
     fi
     "$@"
-    exec sleep "$forever"
+    if [ -n "$foreground" ]; then
+        xprop -spy -notype -root 0i ' $0\n' 'CROUTON_CONNECTED' \
+            | while read _ connected; do
+                if [ "$connected" != 0 ]; then
+                    continue
+                fi
+                # _NET_CLIENT_LIST_STACKING is more reliable than
+                # _NET_ACTIVE_WINDOW for detecting when no windows exist
+                if ! xprop -notype -root '_NET_CLIENT_LIST_STACKING' \
+                            | grep -q '0x'; then
+                    kill "$$"
+                    break
+                fi
+            done
+    fi
 else
     export XMETHOD=xiwi
     exec /usr/local/bin/xinit "$xiwicmd" / "$@"

--- a/chroot-bin/xiwi
+++ b/chroot-bin/xiwi
@@ -9,9 +9,15 @@
 xiwicmd="`readlink -f "$0"`"
 
 if [ "$#" = 0 ]; then
-    echo "Usage: ${0##*/} APPLICATION [PARAMETERS ...]
+    echo "Usage: ${0##*/} [-f] APPLICATION [PARAMETERS ...]
 Launches a windowed session in Chromium OS for any graphical application.
 All parameters are passed to the specified application.
+
+xiwi will normally close when the application returns. Some gui applications
+fork before or during normal operation, which can confuse xiwi and cause it to
+quit prematurely. If your application does not have a parameter that prevents
+it from forking, you can use -f to prevent xiwi from quitting automatically.
+You will need to Ctrl-C xiwi in the terminal to make it quit.
 
 A default window manager will full-screen all windows, unless APPLICATION begins
 with 'start'. You can cycle through multiple windows inside the application via
@@ -21,6 +27,11 @@ manager, specify the full path of the application." 1>&2
     exit 2
 elif [ "$1" = '/' ]; then
     shift 1
+    forever='0'
+    if [ "$1" = '-f' ]; then
+        forever='infinity'
+        shift 1
+    fi
     xsetroot -cursor_name left_ptr
     if [ "${1#start}" = "$1" ]; then
         i3 -c "/etc/crouton/xiwi.conf" &
@@ -61,7 +72,8 @@ elif [ "$1" = '/' ]; then
             /bin/sh "$HOME/.xiwirc" || true
         fi
     fi
-    exec "$@"
+    "$@"
+    exec sleep "$forever"
 else
     export XMETHOD=xiwi
     exec /usr/local/bin/xinit "$xiwicmd" / "$@"

--- a/src/fbserver.c
+++ b/src/fbserver.c
@@ -99,6 +99,14 @@ void kb_release_all() {
 /* X11-related functions */
 
 static int xerror_handler(Display *dpy, XErrorEvent *e) {
+    if (verbose < 1)
+        return 0;
+    char msg[64] = {0};
+    char op[32] = {0};
+    sprintf(msg, "%d", e->request_code);
+    XGetErrorDatabaseText(dpy, "XRequest", msg, "", op, sizeof(op));
+    XGetErrorText(dpy, e->error_code, msg, sizeof(msg));
+    error("%s (%s)", msg, op);
     return 0;
 }
 
@@ -378,9 +386,11 @@ int write_image(const struct screen* screen) {
     reply->cursor_updated = 0;
     while (XCheckTypedEvent(dpy, fixesEvent + XFixesCursorNotify, &ev)) {
         XFixesCursorNotifyEvent* curev = (XFixesCursorNotifyEvent*)&ev;
-        char* name = XGetAtomName(dpy, curev->cursor_name);
-        log(2, "cursor! %ld %s", curev->cursor_serial, name);
-        XFree(name);
+        if (verbose >= 2) {
+            char* name = XGetAtomName(dpy, curev->cursor_name);
+            log(2, "cursor! %ld %s", curev->cursor_serial, name);
+            XFree(name);
+        }
         reply->cursor_updated = 1;
         reply->cursor_serial = curev->cursor_serial;
     }


### PR DESCRIPTION
If you add the -f parameter to xiwi, xiwi will stay open when the program you specified quits, and only exit if you close the window with no windows showing.  This is to handle poorly behaved software that forks and doesn't provide a parameter to disable forking (or if you're too lazy to find it and don't mind that the window doesn't auto-close).

Implements #1538 