### PR TITLE
xiwi apps in a window and in a tab!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ SCRIPTS := \
 	$(wildcard installer/*/*) \
 	$(wildcard src/*) \
 	$(wildcard targets/*)
+EXTPEXE = host-ext/crouton/kiwi.pexe
+EXTPEXESOURCES = $(wildcard host-ext/nacl_src/*.h) \
+				 $(wildcard host-ext/nacl_src/*.cc)
 EXTSOURCES = $(wildcard host-ext/crouton/*)
 GENVERSION = build/genversion.sh
 CONTRIBUTORSSED = build/CONTRIBUTORS.sed
@@ -55,6 +58,9 @@ $(TARGET): $(WRAPPER) $(SCRIPTS) $(GENVERSION) $(GITHEAD) Makefile
 
 $(EXTTARGET): $(EXTSOURCES) Makefile
 	rm -f $(EXTTARGET) && zip -q --junk-paths $(EXTTARGET) $(EXTSOURCES)
+
+$(EXTPEXE): $(EXTPEXESOURCES)
+	$(MAKE) -C host-ext/nacl_src
 
 $(SRCTARGETS): src/$(patsubst crouton%,src/%.c,$@) $($@_DEPS) Makefile
 	gcc $(CFLAGS) $(patsubst crouton%,src/%.c,$@) $($@_LIBS) -o $@

--- a/chroot-bin/croutoncycle
+++ b/chroot-bin/croutoncycle
@@ -88,7 +88,7 @@ for disp in /tmp/.X*-lock; do
             | grep -q 'INTEGER'; then
         displist="$displist $disp"
     elif DISPLAY="$disp" xprop -root 'CROUTON_XMETHOD' 2>/dev/null \
-            | grep -q '= "xiwi"$'; then
+            | grep -q '= "xiwi'; then
         displist="$displist $disp"
         xiwiactive='y'
     fi
@@ -304,7 +304,7 @@ if [ "${destdisp#:}" = "$destdisp" ]; then
     fi
 else
     export DISPLAY="$destdisp"
-    if xprop -root 'CROUTON_XMETHOD' 2>/dev/null | grep -q '= "xiwi"$'; then
+    if xprop -root 'CROUTON_XMETHOD' 2>/dev/null | grep -q '= "xiwi'; then
         if [ -z "$freonowner" -a "$tty" != 'tty1' ]; then
             sudo -n chvt 1
             sleep .1

--- a/chroot-bin/croutoncycle
+++ b/chroot-bin/croutoncycle
@@ -304,7 +304,9 @@ if [ "${destdisp#:}" = "$destdisp" ]; then
     fi
 else
     export DISPLAY="$destdisp"
-    if xprop -root 'CROUTON_XMETHOD' 2>/dev/null | grep -q '= "xiwi'; then
+    xmethod="`xprop -root 'CROUTON_XMETHOD' 2>/dev/null \
+              | sed -n 's/^.*\"\(.*\)\"/\1/p'`"
+    if [ "${xmethod%%-*}" = 'xiwi' ]; then
         if [ -z "$freonowner" -a "$tty" != 'tty1' ]; then
             sudo -n chvt 1
             sleep .1
@@ -314,7 +316,7 @@ else
         if [ -z "$freonowner" ]; then
             host-x11 croutonwmtools raise "$aurawin"
         fi
-        STATUS="`echo -n "X${destdisp}" | websocketcommand`"
+        STATUS="`echo -n "X${destdisp} ${xmethod#*-}" | websocketcommand`"
         if [ "$STATUS" != 'XOK' ]; then
             error 1 "${STATUS#?}"
         fi

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -56,6 +56,8 @@ if [ -z "$XMETHOD" ]; then
         exit 1
     fi
 fi
+xmethodtype="${XMETHOD%%-*}"
+xmethodargs="${XMETHOD#*-}"
 
 # Record the name of the chroot in the root window properties
 if [ -f '/etc/crouton/name' ] && hash xprop 2>/dev/null; then
@@ -74,7 +76,7 @@ if hash croutonclip 2>/dev/null; then
 fi
 
 # Pass through the host cursor and correct mousewheels on xephyr
-if [ "$XMETHOD" = 'xephyr' ]; then
+if [ "$xmethodtype" = 'xephyr' ]; then
     host-x11 croutoncursor "$DISPLAY" &
     if [ -z "$CROUTON_WHEEL_PARAMS" -a -r "$HOME/.croutonwheel" ]; then
         CROUTON_WHEEL_PARAMS="`head -n1 "$HOME/.croutonwheel"`"
@@ -86,7 +88,7 @@ fi
 croutontriggerd &
 
 # Input-related stuff is not needed for kiwi
-if [ "$XMETHOD" != "xiwi" ]; then
+if [ "$xmethodtype" != "xiwi" ]; then
     # Apply the Chromebook keyboard map if installed.
     if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
         setxkbmap -model chromebook
@@ -125,7 +127,7 @@ if [ "$XMETHOD" != "xiwi" ]; then
 fi
 
 # Crouton-in-a-tab: Start fbserver and launch display
-if [ "$XMETHOD" = 'xiwi' ]; then
+if [ "$xmethodtype" = 'xiwi' ]; then
     # The extension sends evdev key codes: fix the keyboard mapping rules
     setxkbmap -rules evdev
     # Reapply xkb map: This fixes autorepeat mask in "xset q"

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -45,7 +45,7 @@ fi
 # Run crouton-specific commands:
 
 # Show chroot specifics for troubleshooting
-croutonversion
+croutonversion 1>&2
 
 if [ -z "$XMETHOD" ]; then
     if [ -f '/etc/crouton/xmethod' ]; then

--- a/chroot-bin/setres
+++ b/chroot-bin/setres
@@ -27,7 +27,7 @@ fi
 
 xmethod="`xprop -root 'CROUTON_XMETHOD' | sed -n 's/^.*\"\(.*\)\"/\1/p'`"
 
-if [ "$xmethod" != "xiwi" ]; then
+if [ "${xmethod%%-*}" != "xiwi" ]; then
     cvt "$x" "$y" "$r" | {
         read -r _
         read -r _ mode data

--- a/chroot-bin/xiwi
+++ b/chroot-bin/xiwi
@@ -109,5 +109,9 @@ else
         \?) error 2 "$USAGE";;
         esac
     done
+    eval "exe=\"\$$OPTIND\""
+    if ! hash "$exe" 2>/dev/null; then
+        error 2 "${0##*/}: $exe: not found"
+    fi
     exec /usr/local/bin/xinit "$xiwicmd" / "$@"
 fi

--- a/chroot-bin/xiwi
+++ b/chroot-bin/xiwi
@@ -61,17 +61,16 @@ elif [ "$1" = '/' ]; then
                     kill "$monpid" 2>/dev/null
                 fi
                 monwid="$wid"
-                xprop -spy -notype -id "$wid" 'WM_NAME' 2>/dev/null | {
-                    while read _ title; do
+                (xprop -spy -notype -id "$wid" 'WM_NAME' 2>/dev/null || echo) \
+                    | while read _ title; do
                         title="${title%\"}"
                         xprop -root -f CROUTON_NAME 8s -set CROUTON_NAME \
-                            "$name/$1: ${title#*\"}"
+                            "$name/$1${title:+": "}${title#*\"}"
                         {
                             echo -n 'C'
                             croutoncycle l
                         } | websocketcommand >/dev/null
-                    done
-                } &
+                    done &
                 monpid="$!"
             done
             if [ -n "$monpid" ]; then

--- a/chroot-bin/xiwi
+++ b/chroot-bin/xiwi
@@ -5,13 +5,12 @@
 
 # Runs the specified X11 application in its own X server in Chromium OS.
 
-. "`dirname "$0"`/../installer/functions"
-xiwicmd="`readlink -f "$0"`"
-
-if [ "$#" = 0 ]; then
-    echo "Usage: ${0##*/} [-f] APPLICATION [PARAMETERS ...]
+USAGE="Usage: ${0##*/} [-f] [-F|-T] APPLICATION [PARAMETERS ...]
 Launches a windowed session in Chromium OS for any graphical application.
 All parameters are passed to the specified application.
+
+By default, the app is launched in a window. Passing -F will launch the app
+full-screen, and passing -T will launch the app in a tab.
 
 xiwi will normally close when the application returns. Some gui applications
 fork before or during normal operation, which can confuse xiwi and cause it to
@@ -20,20 +19,30 @@ it from forking, you can use -f to prevent xiwi from quitting automatically.
 xiwi will quit if you close the Chromium OS window when nothing is displayed.
 
 A default window manager will full-screen all windows, unless APPLICATION begins
-with 'start'. You can cycle through multiple windows inside the application via
-Ctrl-Alt-Tab/Ctrl-Alt-Shift-Tab, or close them via Ctrl-Alt-Shift-Escape.
-If APPLICATION begins with 'start' but you still want to use the default window
-manager, specify the full path of the application." 1>&2
-    exit 2
+with 'start' or is 'xinit'. You can cycle through multiple windows inside the
+application via Ctrl-Alt-Tab/Ctrl-Alt-Shift-Tab, or close them via
+Ctrl-Alt-Shift-Escape.  If APPLICATION begins with 'start' but you still want to
+use the default window manager, specify the full path of the application."
+
+. "`dirname "$0"`/../installer/functions"
+xiwicmd="`readlink -f "$0"`"
+OPTSTRING='FfTt'
+
+if [ "$#" = 0 ]; then
+    error 2 "$USAGE"
 elif [ "$1" = '/' ]; then
     shift 1
     foreground=''
-    if [ "$1" = '-f' ]; then
-        foreground="y"
-        shift 1
-    fi
+    while getopts "$OPTSTRING" f; do
+        case "$f" in
+        f) foreground='y';;
+        t|T|F) :;;
+        \?) error 2 "$USAGE";;
+        esac
+    done
+    shift "$((OPTIND-1))"
     xsetroot -cursor_name left_ptr
-    if [ "${1#start}" = "$1" ]; then
+    if [ "$1" != 'xinit' -a "${1#start}" = "$1" ]; then
         i3 -c "/etc/crouton/xiwi.conf" &
         # Wait for i3 to launch
         xprop -spy -root | grep -q _NET_ACTIVE_WINDOW
@@ -91,6 +100,14 @@ elif [ "$1" = '/' ]; then
             done
     fi
 else
-    export XMETHOD=xiwi
+    export XMETHOD='xiwi-window'
+    while getopts "$OPTSTRING" f; do
+        case "$f" in
+        f) :;;
+        F) export XMETHOD='xiwi-fullscreen';;
+        t|T) export XMETHOD='xiwi-tab';;
+        \?) error 2 "$USAGE";;
+        esac
+    done
     exec /usr/local/bin/xinit "$xiwicmd" / "$@"
 fi

--- a/chroot-bin/xiwi
+++ b/chroot-bin/xiwi
@@ -15,7 +15,8 @@ full-screen, and passing -T will launch the app in a tab.
 xiwi will normally close when the application returns. Some gui applications
 fork before or during normal operation, which can confuse xiwi and cause it to
 quit prematurely. If your application does not have a parameter that prevents
-it from forking, you can use -f to prevent xiwi from quitting automatically.
+it from forking, and crouton is unable to automatically detect the fork, you can
+use -f to prevent xiwi from quitting automatically.
 xiwi will quit if you close the Chromium OS window when nothing is displayed.
 
 A default window manager will full-screen all windows, unless APPLICATION begins
@@ -82,8 +83,10 @@ elif [ "$1" = '/' ]; then
             /bin/sh "$HOME/.xiwirc" || true
         fi
     fi
+    starttime="$(date +%s)"
     "$@"
-    if [ -n "$foreground" ]; then
+    endtime="$(date +%s)"
+    if [ -n "$foreground" -o "$(($endtime-$starttime))" -le 2 ]; then
         xprop -spy -notype -root 0i ' $0\n' 'CROUTON_CONNECTED' \
             | while read _ connected; do
                 if [ "$connected" != 0 ]; then

--- a/chroot-etc/xserverrc
+++ b/chroot-etc/xserverrc
@@ -12,7 +12,7 @@ if [ -z "$XMETHOD" ]; then
     fi
 fi
 
-xserverrc="/etc/crouton/xserverrc-$XMETHOD"
+xserverrc="/etc/crouton/xserverrc-${XMETHOD%%-*}"
 if [ "${XMETHOD##*/}" != "$XMETHOD" -o ! -f "$xserverrc" ]; then
     echo "Invalid X11 backend '$XMETHOD'" 1>&2
     exit 2

--- a/chroot-etc/xserverrc-xiwi
+++ b/chroot-etc/xserverrc-xiwi
@@ -11,7 +11,9 @@ for arg in "$@"; do
     fi
 done
 
-export XMETHOD='xiwi'
+if [ "${XMETHOD%%-*}" != 'xiwi' ]; then
+    export XMETHOD='xiwi'
+fi
 XARGS="-nolisten tcp -config xorg-dummy.conf -logfile $logfile"
 if [ -f /etc/crouton/xserverrc-local ]; then
     . /etc/crouton/xserverrc-local

--- a/chroot-etc/xserverrc-xorg
+++ b/chroot-etc/xserverrc-xorg
@@ -3,7 +3,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-export XMETHOD='xorg'
+if [ "${XMETHOD%%-*}" != 'xorg' ]; then
+    export XMETHOD='xorg'
+fi
 XARGS='-nolisten tcp'
 if [ -f /etc/crouton/xserverrc-local ]; then
     . /etc/crouton/xserverrc-local

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -138,8 +138,8 @@ fi
 
 # Check to ensure that the XMETHOD requested has been installed
 if [ -n "$TMPXMETHOD" ]; then
-    if ! grep -q "^$TMPXMETHOD$" "$CHROOTS/$NAME/.crouton-targets" 2>/dev/null; then
-        error 1 "$CHROOTS/$NAME does not contain XMETHOD '$TMPXMETHOD'"
+    if ! grep -q "^$TMPXMETHOD\(-\|\$\)" "$CHROOTS/$NAME/.crouton-targets"; then
+        error 1 "$CHROOTS/$NAME does not contain XMETHOD '${TMPXMETHOD%%-*}'"
     fi
 fi
 

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -138,7 +138,7 @@ fi
 
 # Check to ensure that the XMETHOD requested has been installed
 if [ -n "$TMPXMETHOD" ]; then
-    if ! grep -q "^$TMPXMETHOD\(-\|\$\)" "$CHROOTS/$NAME/.crouton-targets"; then
+    if ! grep -q "^${TMPXMETHOD%%-*}$" "$CHROOTS/$NAME/.crouton-targets"; then
         error 1 "$CHROOTS/$NAME does not contain XMETHOD '${TMPXMETHOD%%-*}'"
     fi
 fi

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2014 The crouton Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+'use strict';
 
 /* Constants */
 var URL = "ws://localhost:30001/";
@@ -12,11 +13,11 @@ var WINDOW_UPDATE_INTERVAL = 15; /* Update window list every 15" at most */
 /* String to copy to the clipboard if it should be empty */
 var DUMMY_EMPTYSTRING = "%";
 
-LogLevel = {
+var LogLevel = Object.freeze({
     ERROR : "error",
-    INFO : "info",
+    INFO  : "info",
     DEBUG : "debug"
-}
+});
 
 /* Global variables */
 var clipboardholder_; /* textarea used to hold clipboard content */
@@ -110,7 +111,7 @@ function updateWindowList(force) {
 
 /* Called from kiwi (window.js), so we can directly access each window */
 function registerKiwi(displaynum, window) {
-    display = ":" + displaynum
+    var display = ":" + displaynum;
     if (kiwi_win_[display] && kiwi_win_[display].id >= 0) {
         kiwi_win_[display].window = window;
     }
@@ -128,14 +129,13 @@ function closePopup() {
 function refreshUI() {
     updateWindowList(false);
 
+    var icon = "disconnected";
     if (error_)
-        icon = "error"
+        icon = "error";
     else if (!enabled_)
-        icon = "disabled"
+        icon = "disabled";
     else if (active_)
         icon = "connected";
-    else
-        icon = "disconnected";
 
     chrome.browserAction.setIcon(
         {path: {19: icon + '-19.png', 38: icon + '-38.png'}}
@@ -148,10 +148,10 @@ function refreshUI() {
         /* Make sure page is ready */
         if (view.document.readyState === "complete") {
             /* Update "help" link */
-            helplink = view.document.getElementById("help");
+            var helplink = view.document.getElementById("help");
             helplink.onclick = showHelp;
             /* Update enable/disable link. */
-            enablelink = view.document.getElementById("enable");
+            var enablelink = view.document.getElementById("enable");
             if (enabled_) {
                 enablelink.textContent = "Disable";
                 enablelink.onclick = function() {
@@ -175,7 +175,7 @@ function refreshUI() {
             }
 
             /* Update debug mode according to checkbox state. */
-            debugcheck = view.document.getElementById("debugcheck");
+            var debugcheck = view.document.getElementById("debugcheck");
             debugcheck.onclick = function() {
                 debug_ = debugcheck.checked;
                 refreshUI();
@@ -195,7 +195,7 @@ function refreshUI() {
             debugcheck.checked = debug_;
 
             /* Update hidpi mode according to checkbox state. */
-            hidpicheck = view.document.getElementById("hidpicheck");
+            var hidpicheck = view.document.getElementById("hidpicheck");
             if (window.devicePixelRatio > 1) {
                 hidpicheck.onclick = function() {
                     hidpi_ = hidpicheck.checked;
@@ -224,7 +224,7 @@ function refreshUI() {
 
             /* Update window table */
             /* FIXME: Improve UI */
-            windowlist = view.document.getElementById("windowlist");
+            var windowlist = view.document.getElementById("windowlist");
 
             while (windowlist.rows.length > 0) {
                 windowlist.deleteRow(0);
@@ -247,7 +247,7 @@ function refreshUI() {
             }
 
             /* Update logger table */
-            loggertable = view.document.getElementById("logger");
+            var loggertable = view.document.getElementById("logger");
 
             /* FIXME: only update needed rows */
             while (loggertable.rows.length > 0) {
@@ -255,7 +255,7 @@ function refreshUI() {
             }
 
             /* Only update if "show log" is enabled */
-            logcheck = view.document.getElementById("logcheck");
+            var logcheck = view.document.getElementById("logcheck");
             logcheck.onclick = function() {
                 showlog_ = logcheck.checked;
                 refreshUI();
@@ -263,7 +263,7 @@ function refreshUI() {
             logcheck.checked = showlog_;
             if (showlog_) {
                 for (var i = 0; i < logger_.length; i++) {
-                    value = logger_[i];
+                    var value = logger_[i];
 
                     if (value[0] == LogLevel.DEBUG && !debug_)
                         continue;
@@ -483,7 +483,7 @@ function websocketMessage(evt) {
         if (payload.length > 0) {
             windows_ = payload.split('\n').map(
                 function(x) {
-                    m = x.match(/^([^ *]*)\*? +(.*)$/)
+                    var m = x.match(/^([^ *]*)\*? +(.*)$/);
                     if (!m)
                         return null;
 
@@ -491,12 +491,12 @@ function websocketMessage(evt) {
                     if (m[1] != "cros" && !m[1].match(/^:([0-9]+)$/))
                         return null;
 
-                    k = new Object()
+                    var k = new Object();
                     k.display = m[1];
                     k.name = m[2];
                     return k;
                 }
-            ).filter( function(x) { return !!x; } )
+            ).filter( function(x) { return !!x; } );
 
             windows_.forEach(function(k) {
                 var win = kiwi_win_[k.display];
@@ -508,7 +508,7 @@ function websocketMessage(evt) {
                         win.window.setTitle(k.name);
                     }
                 }
-            })
+            });
 
             lastwindowlistupdate_ = new Date().getTime();
             websocket_.send("COK");
@@ -516,10 +516,10 @@ function websocketMessage(evt) {
         refreshUI();
         break;
     case 'X': /* Ask to open a crouton window */
-        display = payload
-        match = display.match(/^:([0-9]+)([- ][^- ]*)*$/)
-        displaynum = match ? match[1] : null;
-        mode = null;
+        var display = payload;
+        var match = display.match(/^:([0-9]+)([- ][^- ]*)*$/);
+        var displaynum = match ? match[1] : null;
+        var mode = null;
         if (displaynum) {
             display = ":" + displaynum;
             mode = match[2].length >= 2 ? match[2].charAt(1) : 'f';
@@ -538,7 +538,7 @@ function websocketMessage(evt) {
                 var winid = kiwi_win_[disps[i]].id;
                 chrome.windows.update(winid, {focused: false});
 
-                minimize = function(win) {
+                var minimize = function(win) {
                     chrome.windows.update(winid, {state: 'minimized'}); };
 
                 chrome.windows.get(winid, function(win) {
@@ -550,7 +550,7 @@ function websocketMessage(evt) {
                     } else {
                         minimize();
                     }
-                })
+                });
             }
         } else if (kiwi_win_[display] && kiwi_win_[display].id >= 0 &&
                    (!kiwi_win_[display].window ||
@@ -576,10 +576,10 @@ function websocketMessage(evt) {
             kiwi_win_[display].isTab = (mode == 't');
             kiwi_win_[display].window = null;
 
-            win = windows_.filter(function(x){return x.display == display})[0];
-            name = win ? win.name : "crouton in a window";
-            create = chrome.windows.create;
-            data = {};
+            var win = windows_.filter(function(x){return x.display == display})[0];
+            var name = win ? win.name : "crouton in a window";
+            var create = chrome.windows.create;
+            var data = {};
 
             if (kiwi_win_[display].isTab) {
                 name = win ? win.name : "crouton in a tab";
@@ -647,16 +647,16 @@ function websocketClose() {
  * clipboard can be transfered. */
 function onFocusChanged(id, isTab) {
     var disps = Object.keys(kiwi_win_);
-    nextfocus_win_ = "cros";
+    var nextfocus_win = "cros";
     for (var i = 0; i < disps.length; i++) {
         if (kiwi_win_[disps[i]].isTab == isTab
                 && kiwi_win_[disps[i]].id == id) {
-            nextfocus_win_ = disps[i];
+            nextfocus_win = disps[i];
             break;
         }
     }
-    if (focus_win_ != nextfocus_win_) {
-        focus_win_ = nextfocus_win_;
+    if (focus_win_ != nextfocus_win) {
+        focus_win_ = nextfocus_win;
         if (active_ && sversion_ >= 2)
             websocket_.send("Cs" + focus_win_);
         printLog("Window " + focus_win_ + " focused", LogLevel.DEBUG);
@@ -702,10 +702,10 @@ function padstr0(i) {
 
 /* Add a message in the log. */
 function printLog(str, level) {
-    date = new Date;
-    datestr = padstr0(date.getHours()) + ":" +
-              padstr0(date.getMinutes()) + ":" +
-              padstr0(date.getSeconds());
+    var date = new Date;
+    var datestr = padstr0(date.getHours()) + ":" +
+                  padstr0(date.getMinutes()) + ":" +
+                  padstr0(date.getSeconds());
 
     if (str.length > 200)
         str = str.substring(0, 197) + "...";
@@ -748,7 +748,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
 chrome.runtime.getPlatformInfo(function(platforminfo) {
     if (platforminfo.os == 'cros') {
         /* On error: disconnect WebSocket, then log errors */
-        onerror = function(msg, url, line) {
+        var onerror = function(msg, url, line) {
             if (websocket_)
                 websocket_.close();
             error("Uncaught JS error: " + msg, false);

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -112,7 +112,7 @@ function updateWindowList(force) {
 /* Called from kiwi (window.js), so we can directly access each window */
 function registerKiwi(displaynum, window) {
     var display = ":" + displaynum;
-    if (kiwi_win_[display] && kiwi_win_[display].id >= 0) {
+    if (kiwi_win_[display] && kiwi_win_[display].id >= -1) {
         kiwi_win_[display].window = window;
     }
 }
@@ -669,7 +669,7 @@ function onRemoved(id, isTab) {
     for (var i = 0; i < disps.length; i++) {
         if (kiwi_win_[disps[i]].isTab == isTab
                 && kiwi_win_[disps[i]].id == id) {
-            kiwi_win_[disps[i]].id = -1;
+            kiwi_win_[disps[i]].id = -2;
             kiwi_win_[disps[i]].isTab = false;
             kiwi_win_[disps[i]].window = null;
             printLog("Window " + disps[i] + " removed", LogLevel.DEBUG);

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -573,7 +573,7 @@ function websocketMessage(evt) {
             /* Open a new window */
             kiwi_win_[display] = new Object();
             kiwi_win_[display].id = -1;
-            kiwi_win_[display].isTab = mode == 't';
+            kiwi_win_[display].isTab = (mode == 't');
             kiwi_win_[display].window = null;
 
             win = windows_.filter(function(x){return x.display == display})[0];
@@ -643,7 +643,7 @@ function websocketClose() {
     checkUpdate(false);
 }
 
-/* Called when window/tab in focus changes: feeback to the extension so the
+/* Called when window/tab in focus changes: feedback to the extension so the
  * clipboard can be transfered. */
 function onFocusChanged(id, isTab) {
     var disps = Object.keys(kiwi_win_);

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -491,8 +491,16 @@ function websocketMessage(evt) {
         break;
     case 'X': /* Ask to open a crouton window */
         display = payload
-        match = display.match(/^:([0-9]+)$/)
+        match = display.match(/^:([0-9]+)([- ][^- ]*)*$/)
         displaynum = match ? match[1] : null
+        if (displaynum) {
+            display = ":" + displaynum;
+        }
+        mode = (match.length > 2 && match[2].length >= 2) ? match[2][1] : 'f'
+        if (mode != 'f' && mode != 'w') {
+            console.log('invalid xiwi mode: ' + mode);
+            mode = 'f';
+        }
         if (!displaynum) {
             /* Minimize all kiwi windows  */
             var disps = Object.keys(kiwi_win_);
@@ -520,7 +528,7 @@ function websocketMessage(evt) {
                     !kiwi_win_[display].window.closing)) {
             /* focus/full screen an existing window */
             var winid = kiwi_win_[display].id;
-            chrome.windows.update(winid, {focused: true});
+            chrome.windows.update(winid, {'focused': true});
             chrome.windows.get(winid, function(win) {
                 if (win.state == "maximized")
                     chrome.windows.update(winid, {'state': 'fullscreen'},
@@ -538,7 +546,8 @@ function websocketMessage(evt) {
             chrome.windows.create({ 'url': "window.html?display=" + displaynum +
                                            "&debug=" + (debug_ ? 1 : 0) +
                                            "&hidpi=" + (hidpi_ ? 1 : 0) +
-                                           "&title=" + encodeURIComponent(name),
+                                           "&title=" + encodeURIComponent(name) +
+                                           "&mode=" + mode,
                                     'type': "popup" },
                                   function(newwin) {
                                       kiwi_win_[display].id = newwin.id;

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -138,7 +138,7 @@ function refreshUI() {
         icon = "disconnected";
 
     chrome.browserAction.setIcon(
-        {path: {'19': icon + '-19.png', '38': icon + '-38.png'}}
+        {path: {19: icon + '-19.png', 38: icon + '-38.png'}}
     );
     chrome.browserAction.setTitle({title: 'crouton: ' + icon});
 
@@ -510,14 +510,14 @@ function websocketMessage(evt) {
 
                 minimize = function(win) {
                     chrome.windows.update(winid,
-                                      {'state': 'minimized'}, function(win) {})}
+                                      {state: 'minimized'}, function(win) {})}
 
                 chrome.windows.get(winid, function(win) {
                     /* To make restore nicer, first exit full screen,
                      * then minimize */
                     if (win.state == "fullscreen") {
                         chrome.windows.update(winid,
-                                              {'state': 'maximized'}, minimize)
+                                              {state: 'maximized'}, minimize)
                     } else {
                         minimize()
                     }
@@ -528,10 +528,10 @@ function websocketMessage(evt) {
                     !kiwi_win_[display].window.closing)) {
             /* focus/full screen an existing window */
             var winid = kiwi_win_[display].id;
-            chrome.windows.update(winid, {'focused': true});
+            chrome.windows.update(winid, {focused: true});
             chrome.windows.get(winid, function(win) {
                 if (win.state == "maximized")
-                    chrome.windows.update(winid, {'state': 'fullscreen'},
+                    chrome.windows.update(winid, {state: 'fullscreen'},
                                           function(win) {})
             })
         } else {
@@ -543,12 +543,12 @@ function websocketMessage(evt) {
             win = windows_.filter(function(x){ return x.display == display })[0]
             name = win ? win.name : "crouton in a window";
 
-            chrome.windows.create({ 'url': "window.html?display=" + displaynum +
+            chrome.windows.create({ url: "window.html?display=" + displaynum +
                                            "&debug=" + (debug_ ? 1 : 0) +
                                            "&hidpi=" + (hidpi_ ? 1 : 0) +
                                            "&title=" + encodeURIComponent(name) +
                                            "&mode=" + mode,
-                                    'type': "popup" },
+                                    type: "popup" },
                                   function(newwin) {
                                       kiwi_win_[display].id = newwin.id;
                                       focus_win_ = display;

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -2,6 +2,8 @@
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */
+'use strict';
+
 document.addEventListener('DOMContentLoaded', function() {
     chrome.extension.getBackgroundPage().refreshUI();
 });

--- a/host-ext/crouton/window.html
+++ b/host-ext/crouton/window.html
@@ -6,11 +6,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="-1">
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="-1" />
     <title>Crouton in a tab</title>
     <script type="text/javascript" src="window.js"></script>
-    <style>
+    <style type="text/css">
       body {
         margin: 0;
         padding: 0;

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2014 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+'use strict';
 
 var CLOSE_TIMEOUT = 2; /* Close window x seconds after disconnect */
 var DEBUG_LEVEL = 2; /* If debug is enabled, use this level in NaCl */
@@ -187,22 +188,22 @@ function handleMessage(message) {
                 newstate = "fullscreen";
             }
             chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                                  {state: newstate}, function(win) {})
-        })
+                                  {state: newstate}, function(win) {});
+        });
     } else if (type == "state" && payload == "hide") {
         /* Hide window */
         chrome.windows.getCurrent(function(win) {
-            minimize = function(win) {
+            var minimize = function(win) {
                 chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
                                       {state: 'minimized'}, function(win) {})}
             /* To make restore nicer, first exit full screen, then minimize */
             if (win.state == "fullscreen") {
                 chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                                      {state: 'maximized'}, minimize)
+                                      {state: 'maximized'}, minimize);
             } else {
-                minimize()
+                minimize();
             }
-        })
+        });
     } else if (type == "resize") {
         i = payload.indexOf("/");
         if (i < 0) return;
@@ -319,4 +320,4 @@ document.addEventListener('DOMContentLoaded', function() {
     setTitle(title_);
 
     registerWindow(true);
-})
+});

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -270,26 +270,23 @@ function handleFocusBlur(evt) {
 }
 
 /* Parse arguments */
-(function() {
-    var args = location.search.substring(1).split('&');
-    for (var i = 0; i < args.length; i++) {
-        var keyval = args[i].split('=');
-        if (keyval[0] == "display") {
-            display_ = keyval[1];
-        } else if (keyval[0] == "title") {
-            title_ = decodeURIComponent(keyval[1]);
-        } else if (keyval[0] == "debug") {
-            debug_ = keyval[1];
-        } else if (keyval[0] == "hidpi") {
-            hidpi_ = keyval[1];
-        } else if (keyval[0] == "mode") {
-            if (keyval[1] == 'f') {
-                chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                                      {state: "fullscreen"});
-            }
+location.search.substring(1).split('&').forEach(function(arg) {
+    var keyval = arg.split('=');
+    if (keyval[0] == "display") {
+        display_ = keyval[1];
+    } else if (keyval[0] == "title") {
+        title_ = decodeURIComponent(keyval[1]);
+    } else if (keyval[0] == "debug") {
+        debug_ = keyval[1];
+    } else if (keyval[0] == "hidpi") {
+        hidpi_ = keyval[1];
+    } else if (keyval[0] == "mode") {
+        if (keyval[1] == 'f') {
+            chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
+                                  {state: "fullscreen"});
         }
     }
-}());
+});
 
 document.addEventListener('DOMContentLoaded', function() {
     listener_ = document.getElementById('listener');

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -262,8 +262,10 @@ function handleFocusBlur(evt) {
 }
 
 /* Start in full screen */
-chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                      {'state': "fullscreen"}, function(win) {})
+if (location.search.search(/[&?]mode=f(&|$)/i) != -1) {
+    chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
+                          {'state': "fullscreen"}, function(win) {})
+}
 
 document.addEventListener('DOMContentLoaded', function() {
     listener_ = document.getElementById('listener');

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 'use strict';
 
-var CLOSE_TIMEOUT = 2; /* Close window x seconds after disconnect */
+var CLOSE_TIMEOUT = 0; /* Close window x seconds after disconnect */
 var DEBUG_LEVEL = 2; /* If debug is enabled, use this level in NaCl */
 var RESIZE_RATE_LIMIT = 300; /* No more than 1 resize query every x ms */
 

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -103,7 +103,7 @@ function setHiDPI(hidpi) {
 }
 
 function setTitle(title) {
-    document.title = "crouton (" + display_ + "): " + title;
+    document.title = title;
 }
 
 /* Set status message */

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -180,18 +180,18 @@ function handleMessage(message) {
                 newstate = "fullscreen";
             }
             chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                                  {'state': newstate}, function(win) {})
+                                  {state: newstate}, function(win) {})
         })
     } else if (type == "state" && payload == "hide") {
         /* Hide window */
         chrome.windows.getCurrent(function(win) {
             minimize = function(win) {
                 chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                                      {'state': 'minimized'}, function(win) {})}
+                                      {state: 'minimized'}, function(win) {})}
             /* To make restore nicer, first exit full screen, then minimize */
             if (win.state == "fullscreen") {
                 chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                                      {'state': 'maximized'}, minimize)
+                                      {state: 'maximized'}, minimize)
             } else {
                 minimize()
             }
@@ -264,7 +264,7 @@ function handleFocusBlur(evt) {
 /* Start in full screen */
 if (location.search.search(/[&?]mode=f(&|$)/i) != -1) {
     chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                          {'state': "fullscreen"}, function(win) {})
+                          {state: "fullscreen"}, function(win) {})
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -15,7 +15,7 @@ var errordiv_ = null; /* error div */
 
 var debug_ = 0; /* Debuging level, passed to NaCl module */
 var hidpi_ = 0; /* HiDPI mode */
-var display_ = null; /* Display number to use */
+var display_ = -1; /* Display number to use */
 var title_ = "crouton"; /* window title */
 var connected_ = false;
 var closing_ = false; /* Disconnected, and waiting for the window to close */
@@ -268,11 +268,27 @@ function handleFocusBlur(evt) {
     KiwiModule_.focus();
 }
 
-/* Start in full screen */
-if (location.search.search(/[&?]mode=f(&|$)/i) != -1) {
-    chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
-                          {state: "fullscreen"}, function(win) {})
-}
+/* Parse arguments */
+(function() {
+    var args = location.search.substring(1).split('&');
+    for (var i = 0; i < args.length; i++) {
+        var keyval = args[i].split('=');
+        if (keyval[0] == "display") {
+            display_ = keyval[1];
+        } else if (keyval[0] == "title") {
+            title_ = decodeURIComponent(keyval[1]);
+        } else if (keyval[0] == "debug") {
+            debug_ = keyval[1];
+        } else if (keyval[0] == "hidpi") {
+            hidpi_ = keyval[1];
+        } else if (keyval[0] == "mode") {
+            if (keyval[1] == 'f') {
+                chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT,
+                                      {state: "fullscreen"});
+            }
+        }
+    }
+}());
 
 document.addEventListener('DOMContentLoaded', function() {
     listener_ = document.getElementById('listener');
@@ -298,22 +314,8 @@ document.addEventListener('DOMContentLoaded', function() {
     warningdiv_.style.display = 'block';
     errordiv_.style.display = 'block';
 
-    /* Parse arguments */
-    var args = location.search.substring(1).split('&');
-    display_ = -1;
-    debug_ = 0;
-    for (var i = 0; i < args.length; i++) {
-        var keyval = args[i].split('=')
-        if (keyval[0] == "display")
-            display_ = keyval[1];
-        else if (keyval[0] == "title")
-            title_ = decodeURIComponent(keyval[1]);
-        else if (keyval[0] == "debug")
-            setDebug(keyval[1]);
-        else if (keyval[0] == "hidpi")
-            setHiDPI(keyval[1]);
-    }
-
+    setDebug(debug_);
+    setHiDPI(hidpi_);
     setTitle(title_);
 
     registerWindow(true);

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -16,7 +16,7 @@ var errordiv_ = null; /* error div */
 var debug_ = 0; /* Debuging level, passed to NaCl module */
 var hidpi_ = 0; /* HiDPI mode */
 var display_ = null; /* Display number to use */
-var title_ = "crouton in a window"; /* window title */
+var title_ = "crouton"; /* window title */
 var connected_ = false;
 var closing_ = false; /* Disconnected, and waiting for the window to close */
 var error_ = false; /* An error has occured */
@@ -68,6 +68,13 @@ function handleCrash(event) {
     }
     registerWindow(false);
 }
+
+/* Handle requests from the background page (for tabs) */
+function handleRequest(message, sender, sendResponse) {
+    if (typeof(window[message.func]) == "function") {
+        window[message.func](message.param);
+    }
+};
 
 /* Change debugging level */
 function setDebug(debug) {
@@ -278,6 +285,7 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('focus', handleFocusBlur);
     window.addEventListener('blur', handleFocusBlur);
     document.addEventListener('visibilitychange', handleFocusBlur);
+    chrome.runtime.onMessage.addListener(handleRequest);
 
     infodiv_ = document.getElementById('info');
     statusdiv_ = document.getElementById('status');


### PR DESCRIPTION
Implements both windowed- and tab launching of chroots. xiwi will default to windowed, xiwi -F will go full-screen, and xiwi -T will go tabbed (using uppercase to avoid conflicts with enter-chroot when we make a startxiwi script down the road).

It's a bit hard to set up to test, as you have to build and run the updated extension along with the code.  If you CAN test though, please do (and report back), because there's quite a lot changed.

TODO: I need to change the order of the info in the title when you're in a tab (chroot+application AFTER titlebar instead of before), because the tab is too small to give useful information.

Resolves #1453