### PR TITLE
Miscellaneous desktop target fixes

### DIFF
--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -129,6 +129,13 @@ install_pkg() {
 }
 
 
+# install_dummy: Installs a dummy package that resolves dependencies. The
+# parameters are a list of crouton-style package names to "install".
+install_dummy() {
+    install_dummy_dist `distropkgs "$@"`
+}
+
+
 # remove: Removes the specified packages. See distropkgs() for package syntax.
 remove() {
     remove_dist `distropkgs "$@"`

--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -54,6 +54,40 @@ install_pkg_dist() {
 }
 
 
+# install_dummy_dist: see install_dummy() in prepare.sh for details.
+install_dummy_dist() {
+    if [ "$#" = 0 ]; then
+        return
+    fi
+    local pkgname="crouton-$1" pkgprovides="$1"
+    shift
+    while [ "$#" != 0 ]; do
+        pkgprovides="$pkgprovides, $1"
+        shift
+    done
+    local tmp="`mktemp -d crouton.XXXXXX --tmpdir=/tmp`"
+    addtrap "rm -rf '$tmp'"
+    cat > "$tmp/control" <<EOF
+Package: $pkgname
+Version: 0
+Architecture: all
+Maintainer: crouton
+Installed-Size: 0
+Provides: $pkgprovides
+Section: misc
+Priority: optional
+Description: Provides a dummy ${pkgname#*-} for crouton
+EOF
+    touch "$tmp/md5sums"
+    echo '2.0' > "$tmp/debian-binary"
+    tar -czf "$tmp/control.tar.gz" -C "$tmp" control md5sums
+    tar -cf "$tmp/data.tar" -T /dev/null
+    ar r "$tmp/$pkgname.deb" \
+        "$tmp/debian-binary" "$tmp/control.tar.gz" "$tmp/data.tar"
+    dpkg -i "$tmp/$pkgname.deb"
+}
+
+
 # remove_dist: see remove() in prepare.sh for details.
 remove_dist() {
     apt-get -y --purge remove "$@"

--- a/targets/gtk-extra
+++ b/targets/gtk-extra
@@ -7,6 +7,7 @@ DESCRIPTION='GTK-based tools including gdebi, gksu, and a simple browser.'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
+install_dummy network-manager network-manager-gnome
 install gdebi gksu netsurf-gtk
 
 # Add netsurf-gtk to Debian-alternatives if not already there

--- a/targets/xfce-desktop
+++ b/targets/xfce-desktop
@@ -7,4 +7,8 @@ DESCRIPTION='Installs Xfce along with common applications. (Approx. 1200MB)'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
+# Avoid /etc/skel/.xscreensaver conflicts
+xsvr='/etc/skel/.xscreensaver'
+[ -f "$xsvr" ] && mv -f "$xsvr" "$xsvr.bak"
 install ubuntu=xubuntu-desktop,task-xfce-desktop -- network-manager xorg
+[ -f "$xsvr.bak" ] && mv -f "$xsvr.bak" "$xsvr"


### PR DESCRIPTION
Fixes the various desktop target issues highlighted in #1408.

Most interesting is the addition of a `install_dummy` command to the installer.

@drinkcat: not sure if we can use `install_dummy` to replace the usage of equivs in xorg.  How important is the depends: line?