### PR TITLE
Error while "make all"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(EXTTARGET): $(EXTSOURCES) Makefile
 $(EXTPEXE): $(EXTPEXESOURCES)
 	$(MAKE) -C host-ext/nacl_src
 
-$(SRCTARGETS): src/$(patsubst crouton%,src/%.c,$@) $($@_DEPS) Makefile
+$(SRCTARGETS): $(patsubst crouton%,src/%.c,$@) $($@_DEPS) Makefile
 	gcc $(CFLAGS) $(patsubst crouton%,src/%.c,$@) $($@_LIBS) -o $@
 
 $(LIBSTARGETS): $(patsubst crouton%.so,src/%.c,$@) $($@_DEPS) Makefile

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ croutoncursor_LIBS = -lX11 -lXfixes -lXrender
 croutonfbserver_LIBS = -lX11 -lXdamage -lXext -lXfixes -lXtst
 croutonwmtools_LIBS = -lX11
 croutonxi2event_LIBS = -lX11 -lXi
+croutonfreon.so_LIBS = -ldl
 
 croutonwebsocket_DEPS = src/websocket.h
 croutonfbserver_DEPS = src/websocket.h
@@ -67,8 +68,8 @@ $(EXTPEXE): $(EXTPEXESOURCES)
 $(SRCTARGETS): src/$(patsubst crouton%,src/%.c,$@) $($@_DEPS) Makefile
 	gcc $(CFLAGS) $(patsubst crouton%,src/%.c,$@) $($@_LIBS) -o $@
 
-croutonfreon.so: src/freon.c Makefile
-	gcc $(CFLAGS) -shared -fPIC src/freon.c -ldl -o croutonfreon.so
+$(LIBSTARGETS): $(patsubst crouton%.so,src/%.c,$@) $($@_DEPS) Makefile
+	gcc $(CFLAGS) -shared -fPIC $(patsubst crouton%.so,src/%.c,$@) $($@_LIBS) -o $@
 
 extension: $(EXTTARGET)
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@
 
 TARGET = crouton
 EXTTARGET = crouton.zip
-SRCTARGETS = $(patsubst src/%.c,crouton%,$(shell find src/ -name *.c -and -not -name freon.c))
-LIBS = croutonfreon.so #croutonxorg.so
+LIBS = src/freon.c
+LIBSTARGETS = $(patsubst src/%.c, crouton%.so, $(LIBS))
+SRCTARGETS = $(patsubst src/%.c,crouton%,$(filter-out $(LIBS),$(wildcard src/*.c)))
 CONTRIBUTORS = CONTRIBUTORS
 WRAPPER = build/wrapper.sh
 SCRIPTS := \
@@ -87,9 +88,9 @@ release: $(CONTRIBUTORS) $(TARGET) $(RELEASE)
 force-release: $(CONTRIBUTORS) $(TARGET) $(RELEASE)
 	$(RELEASE) -f $(TARGET)
 
-all: $(TARGET) $(SRCTARGETS) $(LIBS) $(EXTTARGET)
+all: $(TARGET) $(SRCTARGETS) $(LIBSTARGETS) $(EXTTARGET)
 
 clean:
-	rm -f $(TARGET) $(EXTTARGET) $(SRCTARGETS) $(LIBS)
+	rm -f $(TARGET) $(EXTTARGET) $(SRCTARGETS) $(LIBSTARGETS)
 
 .PHONY: all clean contributors extension release force-release

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,6 @@ $(SRCTARGETS): src/$(patsubst crouton%,src/%.c,$@) $($@_DEPS) Makefile
 croutonfreon.so: src/freon.c Makefile
 	gcc $(CFLAGS) -shared -fPIC src/freon.c -ldl -o croutonfreon.so
 
-croutonxorg.so: src/xorg.c Makefile
-	gcc $(CFLAGS) -shared -fPIC src/xorg.c -ldl -o croutonxorg.so
-
 extension: $(EXTTARGET)
 
 $(CONTRIBUTORS): $(GITHEAD) $(CONTRIBUTORSSED)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 
 TARGET = crouton
 EXTTARGET = crouton.zip
-SRCTARGETS = $(patsubst src/%.c,crouton%,$(wildcard src/*.c))
+SRCTARGETS = $(patsubst src/%.c,crouton%,$(shell find src/ -name *.c -and -not -name freon.c))
+LIBS = croutonfreon.so #croutonxorg.so
 CONTRIBUTORS = CONTRIBUTORS
 WRAPPER = build/wrapper.sh
 SCRIPTS := \
@@ -86,9 +87,9 @@ release: $(CONTRIBUTORS) $(TARGET) $(RELEASE)
 force-release: $(CONTRIBUTORS) $(TARGET) $(RELEASE)
 	$(RELEASE) -f $(TARGET)
 
-all: $(TARGET) $(SRCTARGETS) $(EXTTARGET)
+all: $(TARGET) $(SRCTARGETS) $(LIBS) $(EXTTARGET)
 
 clean:
-	rm -f $(TARGET) $(EXTTARGET) $(SRCTARGETS)
+	rm -f $(TARGET) $(EXTTARGET) $(SRCTARGETS) $(LIBS)
 
 .PHONY: all clean contributors extension release force-release


### PR DESCRIPTION
I think there is an error in determining $(SRCTARGETS) in Makefile, trying to build "croutonfreon" (not "croutonfreon.so"). I got errors while "make all":

gcc -g -Wall -Werror -Os src/freon.c  -o croutonfreon
/usr/lib/gcc/x86_64-pc-linux-gnu/4.8.3/../../../../lib64/crt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
/tmp/ccanIAv9.o: In function `preload_init':
/home/toor/projects/crouton/src/freon.c:43: undefined reference to `dlsym'
/home/toor/projects/crouton/src/freon.c:44: undefined reference to `dlsym'
/home/toor/projects/crouton/src/freon.c:45: undefined reference to `dlsym'

First error -- src/freon.c have no main() (thats because we`re trying to build it as binary, not library)
Other errors -- just missing "-ldl" (presents in "croutonfreon.so" target).

I think you should build libraries as separate target (as in my patch) or just move freon.c to lib/ folder or something like that.

src/xorg.c is missing anyway..