### PR TITLE
Suggest using enter-chroot instead of startcli on Freon systems

### DIFF
--- a/host-bin/startcli
+++ b/host-bin/startcli
@@ -14,6 +14,12 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
+if [ -f /sbin/frecon ]; then
+    echo "$APPLICATION no longer works on systems using 'Freon'.
+Please use enter-chroot instead." 1>&2
+    exit 2
+fi
+
 export TERM='linux'
 exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t cli-extra -l \
     "$@" "" openvt -vws --


### PR DESCRIPTION
Added check for `/sbin/frecon` and exit with suggestion to `enter-chroot` instead.