### PR TITLE
Support native Xorg in Freon on ARM

### DIFF
--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -130,7 +130,8 @@ install_pkg() {
 
 
 # install_dummy: Installs a dummy package that resolves dependencies. The
-# parameters are a list of crouton-style package names to "install".
+# parameters are a list of crouton-style package names to "install", optionally
+# followed by -- and the packages it depends on.
 install_dummy() {
     install_dummy_dist `distropkgs "$@"`
 }

--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -62,9 +62,21 @@ install_dummy_dist() {
     local pkgname="crouton-$1" pkgprovides="$1"
     shift
     while [ "$#" != 0 ]; do
+        if [ "$1" = '--' ]; then
+            shift
+            break
+        fi
         pkgprovides="$pkgprovides, $1"
         shift
     done
+    local pkgdepends="$1"
+    if [ "$#" != 0 ]; then
+        shift
+        while [ "$#" != 0 ]; do
+            pkgdepends="$pkgdepends, $1"
+            shift
+        done
+    fi
     local tmp="`mktemp -d crouton.XXXXXX --tmpdir=/tmp`"
     addtrap "rm -rf '$tmp'"
     cat > "$tmp/control" <<EOF
@@ -74,6 +86,7 @@ Architecture: all
 Maintainer: crouton
 Installed-Size: 0
 Provides: $pkgprovides
+Depends: $pkgdepends
 Section: misc
 Priority: optional
 Description: Provides a dummy ${pkgname#*-} for crouton
@@ -84,7 +97,8 @@ EOF
     tar -cf "$tmp/data.tar" -T /dev/null
     ar r "$tmp/$pkgname.deb" \
         "$tmp/debian-binary" "$tmp/control.tar.gz" "$tmp/data.tar"
-    dpkg -i "$tmp/$pkgname.deb"
+    dpkg -i --force-depends "$tmp/$pkgname.deb"
+    apt-get -fy install
 }
 
 

--- a/targets/x11
+++ b/targets/x11
@@ -2,17 +2,14 @@
 # Copyright (c) 2015 The crouton Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-if grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo || \
+if [ -f /sbin/frecon ]; then
+    REQUIRES='xorg'
+elif grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo || \
         ([ "${ARCH#arm}" != "$ARCH" ] && \
         awk -F= '/_RELEASE_VERSION=/ { exit !(int($2) < 6689) }' \
         '/etc/lsb-release'); then
     # Xorg won't work on Samsung ARM devices or K1 on release less than 6689
-    # But if we're on Freon, we can't use xephyr either, so xiwi's all we have
-    if [ -f /sbin/frecon ]; then
-        REQUIRES='xiwi'
-    else
-        REQUIRES='xephyr'
-    fi
+    REQUIRES='xephyr'
 else
     REQUIRES='xorg'
 fi

--- a/targets/x11
+++ b/targets/x11
@@ -3,7 +3,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 if [ -f /sbin/frecon ]; then
-    REQUIRES='xorg'
+    # Wheezy/Kali are too old to use KMS well
+    if release -le wheezy -le kali; then
+        REQUIRES='xiwi'
+    else
+        REQUIRES='xorg'
+    fi
 elif grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo || \
         ([ "${ARCH#arm}" != "$ARCH" ] && \
         awk -F= '/_RELEASE_VERSION=/ { exit !(int($2) < 6689) }' \

--- a/targets/xorg
+++ b/targets/xorg
@@ -115,19 +115,34 @@ END
     apt-get -y --force-yes --no-install-recommends dist-upgrade -f
 fi
 
-install xorg -- xserver-xorg-video-fbdev$backport
+# If the system has an Intel FBC-capable video card but has too old a driver to
+# support the chipset, disable hardware acceleration.
+hasfbc=''
+fbcsupport='y'
+if grep -q 1 '/sys/module/i915/parameters/i915_enable_fbc' 2>/dev/null; then
+    hasfbc=y
+    if release -le wheezy -le kali; then
+        fbcsupport=''
+    fi
+fi
+inteldriver=''
+if [ "${ARCH#arm}" = "$ARCH" ]; then
+    inteldriver=xserver-xorg-video-intel$backport
+fi
+
+install xorg -- xserver-xorg-video-fbdev$backport $inteldriver
 if [ ! -f "/sys/class/tty/tty0/active" ]; then
     install xserver-xorg-video-modesetting$backport
 else
     install xserver-xorg-video-fbdev$backport
 fi
-if [ "${ARCH#arm}" = "$ARCH" ]; then
-    install xserver-xorg-video-intel$backport
+if [ -z "$hasfbc" -o -n "$fbcsupport" ]; then
+    install $inteldriver
 fi
 
 # This is a system with framebuffer compression, so we need SNA+tearfree
 xorgconf='/usr/share/X11/xorg.conf.d/20-crouton-intel-sna.conf'
-if grep -q 1 '/sys/module/i915/parameters/i915_enable_fbc' 2>/dev/null; then
+if [ -n "$hasfbc" -a -n "$fbcsupport" ]; then
     mkdir -p "${xorgconf%/*}"
     ln -sfT /etc/crouton/xorg-intel-sna.conf "$xorgconf"
 else

--- a/targets/xorg
+++ b/targets/xorg
@@ -25,15 +25,23 @@ if [ ! -f "/sys/class/tty/tty0/active" ]; then
     compile freon '-ldl' so
 fi
 
-ltspackages=''
-# On non-ARM precise, install lts-trusty xorg server to support newer hardware
-# if kernel version != 3.4 (lts-trusty mesa requires version >=3.6)
-if [ "${ARCH#arm}" = "$ARCH" ] && release -eq precise \
-        && ! uname -r | grep -q "^3.4."; then
-    # We still install xorg later to pull in its dependencies
-    ltspackages='-lts-trusty'
-    install --minimal "xserver-xorg$ltspackages" "libgl1-mesa-glx$ltspackages" \
-        "xserver-xorg-input-synaptics$ltspackages"
+backport=''
+# Pull in backported Xorg when possible on precise to support newer hardware
+if release -eq precise; then
+    if [ "${ARCH#arm}" = "$ARCH" ]; then
+        # Note: lts-trusty mesa requires kernel version >=3.6
+        if  ! uname -r | grep -q "^3.4."; then
+            backport='-lts-trusty'
+        fi
+    else
+        # ARM only offers quantal backport at the moment
+        backport='-lts-quantal'
+    fi
+    if [ -n "$backport" ]; then
+        # We still install xorg later to pull in its dependencies
+        install --minimal "xserver-xorg$backport" "libgl1-mesa-glx$backport" \
+            "xserver-xorg-input-synaptics$backport"
+    fi
 fi
 
 # On saucy onwards, if kernel version is 3.4, manually pin down old mesa
@@ -104,9 +112,9 @@ END
     apt-get -y --force-yes --no-install-recommends dist-upgrade -f
 fi
 
-install xorg xserver-xorg-video-fbdev$ltspackages
+install xorg xserver-xorg-video-fbdev$backport
 if [ "${ARCH#arm}" = "$ARCH" ]; then
-    install xserver-xorg-video-intel$ltspackages
+    install xserver-xorg-video-intel$backport
 fi
 
 # This is a system with framebuffer compression, so we need SNA+tearfree

--- a/targets/xorg
+++ b/targets/xorg
@@ -36,8 +36,6 @@ if release -eq precise; then
     else
         # ARM only offers quantal backport at the moment
         backport='-lts-quantal'
-        # Also, xorg is packaged wrong and doesn't recognize the backport
-        install_dummy xserver-xorg
     fi
     if [ -n "$backport" ]; then
         # We still install xorg later to pull in its dependencies
@@ -130,7 +128,20 @@ if [ "${ARCH#arm}" = "$ARCH" ]; then
     inteldriver=xserver-xorg-video-intel$backport
 fi
 
-install xorg -- xserver-xorg-video-fbdev$backport $inteldriver
+# Install xorg, no video drivers
+if [ "${ARCH#arm}" != "$ARCH" ] && release -eq precise; then
+    # xorg is packaged wrong and conflicts with xserver-xorg-lts-quantal so
+    # replace it with something not broken
+    install_dummy xorg -- xserver-xorg$backport libgl1-mesa-glx$backport \
+        libgl1-mesa-dri$backport libglu1-mesa xfonts-base x11-apps \
+        x11-session-utils x11-utils x11-xfs-utils x11-xkb-utils \
+        x11-xserver-utils xauth xinit xfonts-utils xkb-data xorg-docs-core \
+        xterm x11-common xinput
+else
+    install xorg -- xserver-xorg-video-fbdev$backport $inteldriver
+fi
+
+# Install relevant video drivers
 if [ ! -f "/sys/class/tty/tty0/active" ]; then
     install xserver-xorg-video-modesetting$backport
 else

--- a/targets/xorg
+++ b/targets/xorg
@@ -40,6 +40,7 @@ if release -eq precise; then
     if [ -n "$backport" ]; then
         # We still install xorg later to pull in its dependencies
         install --minimal "xserver-xorg$backport" "libgl1-mesa-glx$backport" \
+            "libegl1-mesa$backport" "libgles2-mesa$backport" \
             "xserver-xorg-input-synaptics$backport"
     fi
 fi

--- a/targets/xorg
+++ b/targets/xorg
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
-    if grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo; then
+    if grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo && [ ! -f /sbin/frecon ]; then
         error 1 'xorg target does not work on Samsung ARM devices.'
     fi
 fi

--- a/targets/xorg
+++ b/targets/xorg
@@ -77,9 +77,7 @@ installvideodrivers=''
 removevideodrivers=''
 if [ -n "$freon" ]; then
     installvideodrivers="$modesetting"
-    if [ -z "$(list_uninstalled "$fbdev")" ]; then
-        removevideodrivers="$fbdev"
-    fi
+    removevideodrivers="$fbdev"
 else
     installvideodrivers="$fbdev"
 fi
@@ -87,7 +85,7 @@ if [ -n "$inteldriver" ]; then
     # If we need SNA (for fbc) but don't have it, don't install intel
     if [ -z "$intelhasfbc" -o -n "$intelfbcsupport" ]; then
         installvideodrivers="$installvideodrivers $inteldriver"
-    elif [ -z "$(list_uninstalled "$inteldriver")" ]; then
+    else
         removevideodrivers="$removevideodrivers $inteldriver"
     fi
 fi

--- a/targets/xorg
+++ b/targets/xorg
@@ -36,6 +36,8 @@ if release -eq precise; then
     else
         # ARM only offers quantal backport at the moment
         backport='-lts-quantal'
+        # Also, xorg is packaged wrong and doesn't recognize the backport
+        install_dummy xserver-xorg
     fi
     if [ -n "$backport" ]; then
         # We still install xorg later to pull in its dependencies
@@ -113,7 +115,12 @@ END
     apt-get -y --force-yes --no-install-recommends dist-upgrade -f
 fi
 
-install xorg xserver-xorg-video-fbdev$backport
+install xorg -- xserver-xorg-video-fbdev$backport
+if [ ! -f "/sys/class/tty/tty0/active" ]; then
+    install xserver-xorg-video-modesetting$backport
+else
+    install xserver-xorg-video-fbdev$backport
+fi
 if [ "${ARCH#arm}" = "$ARCH" ]; then
     install xserver-xorg-video-intel$backport
 fi

--- a/targets/xorg
+++ b/targets/xorg
@@ -70,8 +70,9 @@ if [ "${ARCH#arm}" = "$ARCH" ]; then
 fi
 
 # Catalog relevant and irrelevant video drivers
+# Debian sid has modesetting built into xserver-xorg-core
 fbdev="xserver-xorg-video-fbdev$backport"
-modesetting="xserver-xorg-video-modesetting$backport"
+modesetting="xserver-xorg-video-modesetting$backport,debian~sid="
 installvideodrivers=''
 removevideodrivers=''
 if [ -n "$freon" ]; then

--- a/targets/xorg
+++ b/targets/xorg
@@ -20,37 +20,88 @@ XMETHOD="${XMETHOD:-xorg}"
 # Migration from ambiguous XMETHOD
 rm -f '/etc/crouton/xserverrc-x11'
 
-# On Freon, we need crazy xorg hacks
+
+# Figure out what we need on this system
+
+# Freon?
+freon=''
 if [ ! -f "/sys/class/tty/tty0/active" ]; then
-    compile freon '-ldl' so
+    freon='y'
 fi
 
-backport=''
 # Pull in backported Xorg when possible on precise to support newer hardware
+backport=''
 if release -eq precise; then
     if [ "${ARCH#arm}" = "$ARCH" ]; then
         # Note: lts-trusty mesa requires kernel version >=3.6
-        if  ! uname -r | grep -q "^3.4."; then
+        if ! uname -r | grep -q "^3.4."; then
             backport='-lts-trusty'
         fi
     else
         # ARM only offers quantal backport at the moment
         backport='-lts-quantal'
     fi
-    if [ -n "$backport" ]; then
-        # We still install xorg later to pull in its dependencies
-        install --minimal "xserver-xorg$backport" "libgl1-mesa-glx$backport" \
-            "libegl1-mesa$backport" "libgles2-mesa$backport" \
-            "xserver-xorg-input-synaptics$backport"
+fi
+
+# Intel?
+inteldriver=''
+intelhasfbc=''
+pinmesa=''
+intelfbcsupport='y'
+if [ "${ARCH#arm}" = "$ARCH" ]; then
+    inteldriver="xserver-xorg-video-intel$backport"
+
+    # If the system has an Intel FBC-capable video card but has too old a driver
+    # to support the chipset, we'll need to disable hardware acceleration.
+    if grep -q 1 '/sys/module/i915/parameters/i915_enable_fbc' 2>/dev/null; then
+        intelhasfbc=y
+        if release -le wheezy -le kali; then
+            intelfbcsupport=''
+        fi
+    fi
+
+    # On saucy onwards, if kernel version is 3.4, manually pin down old mesa
+    # libraries, as new ones require version >=3.6 (see issue #704).
+    # This is only required on non-Atom Intel chipsets (Atom uses i915 dri driver)
+    if release -ge saucy && uname -r | grep -q "^3.4." &&
+            ! grep -q 0xa0 /sys/class/graphics/fb0/device/device; then
+        pinmesa='y'
     fi
 fi
 
-# On saucy onwards, if kernel version is 3.4, manually pin down old mesa
-# libraries, as new ones require version >=3.6 (see issue #704).
-# This is only required on non-Atom Intel chipsets (Atom uses i915 dri driver)
-if release -ge saucy && uname -r | grep -q "^3.4." &&
-        grep -q 0x8086 /sys/class/graphics/fb0/device/vendor 2>/dev/null &&
-        ! grep -q 0xa0 /sys/class/graphics/fb0/device/device 2>/dev/null; then
+# Catalog relevant and irrelevant video drivers
+fbdev="xserver-xorg-video-fbdev$backport"
+modesetting="xserver-xorg-video-modesetting$backport"
+installvideodrivers=''
+removevideodrivers=''
+if [ -n "$freon" ]; then
+    installvideodrivers="$modesetting"
+    if [ -z "$(list_uninstalled "$fbdev")" ]; then
+        removevideodrivers="$fbdev"
+    fi
+else
+    installvideodrivers="$fbdev"
+fi
+if [ -n "$inteldriver" ]; then
+    # If we need SNA (for fbc) but don't have it, don't install intel
+    if [ -z "$intelhasfbc" -o -n "$intelfbcsupport" ]; then
+        installvideodrivers="$installvideodrivers $inteldriver"
+    elif [ -z "$(list_uninstalled "$inteldriver")" ]; then
+        removevideodrivers="$removevideodrivers $inteldriver"
+    fi
+fi
+
+
+# On Freon, we need crazy xorg hacks
+if [ -n "$freon" ]; then
+    compile freon '-ldl' so
+fi
+
+# Pin precise's version of mesa if necessary
+pinfile='/etc/apt/preferences.d/precise-mesa-pin'
+pinlist='/etc/apt/sources.list.d/precise.list'
+pindummypkg='libwayland-egl1-dummy'
+if [ -n "$pinmesa" ]; then
     # Create a dummy libwayland-egl1 package, to satisfy dependencies
     # (the libraries are actually provided by libegl1-mesa-drivers in precise)
     install --minimal --asdeps equivs
@@ -63,7 +114,7 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 
-Package: libwayland-egl1-dummy
+Package: $pindummypkg
 Version: 8.0.4
 Depends: libegl1-mesa-drivers
 Provides: libwayland-egl1
@@ -73,13 +124,13 @@ END
     # Add precise package sources
     mirror="`detect_mirror`"
 
-    cat > "/etc/apt/sources.list.d/precise.list" <<END
+    cat > "$pinlist" <<END
 deb $mirror precise main
 deb $mirror precise-updates main
 deb $mirror precise-security main
 END
 
-    cat > "/etc/apt/preferences.d/precise-mesa-pin" <<END
+    cat > "$pinfile" <<END
 # Do not install any packages from precise by default
 Package: *
 Pin: release n=precise
@@ -111,55 +162,43 @@ END
     # dependency of ubuntu-minimal-1.267 (precise), which we did not install.
     # Looks like an apt bug, I guess we can live with that.
     apt-get -y --force-yes --no-install-recommends dist-upgrade -f
+elif [ -f "$pinfile" -o -f "$pinlist" ]; then
+    # No longer need the pin; remove it
+    rm -f "$pinfile" "$pinlist"
+    apt-get update || true
+    dpkg -r --force-depends "$pindummypkg"
+    apt-get -y --force-yes --no-install-recommends dist-upgrade -f
 fi
 
-# If the system has an Intel FBC-capable video card but has too old a driver to
-# support the chipset, disable hardware acceleration.
-hasfbc=''
-fbcsupport='y'
-if grep -q 1 '/sys/module/i915/parameters/i915_enable_fbc' 2>/dev/null; then
-    hasfbc=y
-    if release -le wheezy -le kali; then
-        fbcsupport=''
-    fi
-fi
-inteldriver=''
-if [ "${ARCH#arm}" = "$ARCH" ]; then
-    inteldriver=xserver-xorg-video-intel$backport
+# Install backported xorg instead of the default one
+if [ -n "$backport" ]; then
+    # We still install xorg later to pull in its dependencies
+    install --minimal "xserver-xorg$backport" "libgl1-mesa-glx$backport" \
+        "libegl1-mesa$backport" "libgles2-mesa$backport" \
+        "xserver-xorg-input-synaptics$backport" $installvideodrivers
 fi
 
 # Install xorg, no video drivers
-if [ "${ARCH#arm}" != "$ARCH" ] && release -eq precise; then
-    # xorg is packaged wrong and conflicts with xserver-xorg-lts-quantal so
-    # replace it with something not broken
+if [ -z "$inteldriver" -a -n "$backport" ] && release -eq precise; then
+    # xorg is packaged wrong on ARM and conflicts with xserver-xorg-lts-quantal
+    # so replace it with something not broken
     install_dummy xorg -- xserver-xorg$backport libgl1-mesa-glx$backport \
         libgl1-mesa-dri$backport libglu1-mesa xfonts-base x11-apps \
         x11-session-utils x11-utils x11-xfs-utils x11-xkb-utils \
         x11-xserver-utils xauth xinit xfonts-utils xkb-data xorg-docs-core \
         xterm x11-common xinput
 else
-    install xorg -- xserver-xorg-video-fbdev$backport $inteldriver
+    install xorg $installvideodrivers -- xserver-xorg-video-all$backport
 fi
 
-# Install relevant video drivers
-fbdev=xserver-xorg-video-fbdev$backport
-if [ ! -f "/sys/class/tty/tty0/active" ]; then
-    install xserver-xorg-video-modesetting$backport
-    if [ -z "$(list_uninstalled $fbdev)" ]; then
-        remove $fbdev
-    fi
-else
-    install $fbdev
-fi
-if [ -z "$hasfbc" -o -n "$fbcsupport" ]; then
-    install $inteldriver
-elif [ -n "$inteldriver" ] && [ -z "$(list_uninstalled $inteldriver)" ]; then
-    remove $inteldriver
+# Remove bad video drivers
+if [ -n "$removevideodrivers" ]; then
+    remove $removevideodrivers
 fi
 
-# This is a system with framebuffer compression, so we need SNA+tearfree
+# If this is a system with framebuffer compression, we need SNA+tearfree
 xorgconf='/usr/share/X11/xorg.conf.d/20-crouton-intel-sna.conf'
-if [ -n "$hasfbc" -a -n "$fbcsupport" ]; then
+if [ -n "$intelhasfbc" -a -n "$intelfbcsupport" ]; then
     mkdir -p "${xorgconf%/*}"
     ln -sfT /etc/crouton/xorg-intel-sna.conf "$xorgconf"
 else

--- a/targets/xorg
+++ b/targets/xorg
@@ -142,13 +142,19 @@ else
 fi
 
 # Install relevant video drivers
+fbdev=xserver-xorg-video-fbdev$backport
 if [ ! -f "/sys/class/tty/tty0/active" ]; then
     install xserver-xorg-video-modesetting$backport
+    if [ -z "$(list_uninstalled $fbdev)" ]; then
+        remove $fbdev
+    fi
 else
-    install xserver-xorg-video-fbdev$backport
+    install $fbdev
 fi
 if [ -z "$hasfbc" -o -n "$fbcsupport" ]; then
     install $inteldriver
+elif [ -n "$inteldriver" ] && [ -z "$(list_uninstalled $inteldriver)" ]; then
+    remove $inteldriver
 fi
 
 # This is a system with framebuffer compression, so we need SNA+tearfree

--- a/test/tests/35-xorg
+++ b/test/tests/35-xorg
@@ -5,7 +5,7 @@
 
 # All supported releases should be able to launch an xorg server
 if [ -z "$release" ]; then
-    if grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo; then
+    if grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo && [ ! -f /sbin/frecon ]; then
         log "xorg is not available on Samsung ARM. Skipping test."
     else
         echo "all"


### PR DESCRIPTION
With Freon comes support for native xorg on all ARM platforms!  This fixes #1606.

Note that *this is not GPU acceleration*, but it IS faster than xephyr and xiwi.

Also sort of fixes #1505, in that x11 will always give you a working target.  The situation is improved for non-freon wheezy/kali, and totally avoided by requiring xiwi on freon wheezy/kali.