### PR TITLE
disallow xorg to listen for tcp

### DIFF
--- a/chroot-etc/xserverrc-xorg
+++ b/chroot-etc/xserverrc-xorg
@@ -39,7 +39,7 @@ if [ ! -f "/sys/class/tty/tty0/active" ]; then
             logfile="/tmp/Xorg.crouton.$disp.log"
         fi
     done
-    XARGS="-logfile $logfile"
+    XARGS="$XARGS -logfile $logfile"
     export LD_PRELOAD="/usr/local/lib/croutonfreon.so:$LD_PRELOAD"
 fi
 


### PR DESCRIPTION
The XARGS variable should have appended keys to an existing variable, but instead, 
re-declaration took place and now xorg is being globally available for anyone.

It was fun finding this out while being connected to public networks ;))