### PR TITLE
Added a volume script with interface similar to brightness.

### DIFF
--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -3,8 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# This script uses amixer to present an interface similar to the
-# brightness script for crouton.
+# This script uses amixer to present an interface similar to the brightness
+# script for crouton.
 
 set -e
 set -u
@@ -15,6 +15,7 @@ APPLICATION="${0##*/}"
 USAGE="$APPLICATION [set] [0-100]
 $APPLICATION up|down [0-100]
 $APPLICATION mute [set|unset|toggle]
+$APPLICATION get [all|volume|mute]
 
 This script changes the volume of the current output
 device, as would changing it with the shortcut keys or
@@ -25,6 +26,7 @@ Shortcut invocations:
     $APPLICATION down   decreases by $DEFAULT_VOLUME_DELTA
     $APPLICATION mute   sets muted
     $APPLICATION 0-100  sets volume to given value
+    $APPLICATION get    shortcut for get all
 "
 # The control which controls the current output.
 ALSA_CONTROL="Master"
@@ -32,6 +34,18 @@ ALSA_CONTROL="Master"
 # Tiny sugar coating around amixer for common parameters.
 _amixer() {
     amixer -Dcras "$@"
+}
+amixer_get_value() {
+    # $1 is the control name to get the value for
+    _amixer cget "name=$1" | sed -n \
+        -e "/[[:space:]]\+:/s/.*=//p"
+    #       ^              ^      ^ Print the line.
+    #       ^              ^ Replace everything before the equal sign.
+    #       ^ Search for the line with spaces and a colon (the value).
+}
+
+get_volume() {
+    amixer_get_value "$ALSA_CONTROL Playback Volume"
 }
 
 set_volume() {
@@ -41,11 +55,7 @@ set_volume() {
 
 get_is_muted() {
     # Get the alsa state of the control.
-    local state="$(_amixer cget "name=$ALSA_CONTROL Playback Switch" | sed -n \
-        -e "/[[:space:]]\+:/s/.*=//p")"
-    #       ^              ^      ^ Print the line.
-    #       ^              ^ Replace everything before the equal sign.
-    #       ^ Search for the line with spaces and a colon (the value).
+    local state="$(amixer_get_value "$ALSA_CONTROL Playback Switch")"
 
     # Muted is off (control is off)
     if [ "$state" = "on" ]; then
@@ -54,6 +64,14 @@ get_is_muted() {
     else
         # Is muted, so is_muted is true
         return 0
+    fi
+}
+
+get_is_muted_as_text() {
+    if get_is_muted; then
+        echo "yes"
+    else
+        echo "no"
     fi
 }
 
@@ -152,6 +170,21 @@ set|[0-9]|[0-9][0-9]|100)
         exit 1
     fi
     set_volume "$amount"
+    ;;
+get)
+    action="${1-all}"
+    case "$action" in
+    mute) get_is_muted_as_text ;;
+    volume) get_volume ;;
+    all)
+        echo "Volume: $(get_volume)"
+        echo "Muted: $(get_is_muted_as_text)"
+        ;;
+    *)
+        error_help "Invalid action: $action for get."
+        exit 1
+        ;;
+    esac
     ;;
 *)
     error_help "Error: Unkown command $cmd"

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -70,6 +70,13 @@ unmute() {
 
 relative_volume() {
     local delta="$1"
+
+    # Check that this is integer-ish enough.
+    if ! [ "$delta" -eq "$delta" ] 2>/dev/null; then
+        error_help "Error: $APPLICATION <up|down> needs a number [0-100]"
+        exit 1
+    fi
+
     if get_is_muted; then
         if [ "$delta" -lt 0 ]; then
             set_volume 0
@@ -78,10 +85,9 @@ relative_volume() {
     else
         # Is the volume going down or up?
         if [ "$delta" -lt 0 ]; then
-            # Down, then we need to make that number positive
-            : $(( delta=delta * -1 ))
+            # Going down, we strip the leading minus sign,
             # And suffix the minus sign.
-            set_volume "${delta}-"
+            set_volume "${delta#*-}-"
         else
             # Only suffix the plus sign.
             set_volume "${delta}+"
@@ -90,14 +96,16 @@ relative_volume() {
 }
 
 print_help() {
-    # Prints the usage message.
-    # Can also get a message to show first.
-    [ $# -gt 0 ] && echo "$@"
     echo "$USAGE"
+}
+error_help() {
+    # Prints an error message and the usage to stderr
+    [ $# -gt 0 ] && echo "$@" 1>&2
+    print_help 1>&2
 }
 
 if [ $# -lt 1 ]; then
-    print_help "Error: $APPLICATION needs at least a command." 1>&2
+    error_help "Error: $APPLICATION needs at least a command."
     exit 1
 fi
 
@@ -109,25 +117,19 @@ h*|-h*|--help)
     print_help
     ;;
 up)
-    relative_volume "${1-$DEFAULT_VOLUME_DELTA}"
+    relative_volume "${1:-$DEFAULT_VOLUME_DELTA}"
     ;;
 down)
-    relative_volume "-${1-$DEFAULT_VOLUME_DELTA}"
+    relative_volume "-${1:-$DEFAULT_VOLUME_DELTA}"
     ;;
 mute)
     action="${1-set}"
     case "$action" in
-    "toggle")
-        toggle_mute
-        ;;
-    set)
-        mute
-        ;;
-    unset)
-        unmute
-        ;;
+    toggle) toggle_mute ;;
+    set) mute ;;
+    unset) unmute ;;
     *)
-        print_help "Invalid action: $action for mute." 1>&2
+        error_help "Invalid action: $action for mute."
         exit 1
         ;;
     esac
@@ -136,7 +138,7 @@ set|[0-9]|[0-9][0-9]|100)
     amount="$cmd"
     # First, check that we received a value to set the volume to.
     if [ $# -eq 0 ] && [ "$cmd" = "set" ]; then
-        print_help "Error: $APPLICATION set needs an amount to set." 1>&2
+        error_help "Error: $APPLICATION set needs an amount to set."
         exit 1
     fi
     # The value /could/ have been a parameter or the command itself.
@@ -146,13 +148,13 @@ set|[0-9]|[0-9][0-9]|100)
     fi
     # Check that this is integer-ish enough.
     if ! [ "$amount" -eq "$amount" ] 2>/dev/null; then
-        print_help "Error: $APPLICATION set needs a number [0-100]" 1>&2
+        error_help "Error: $APPLICATION set needs a number [0-100]"
         exit 1
     fi
     set_volume "$amount"
     ;;
 *)
-    print_help "Error: Unkown command $cmd" 1>&2
+    error_help "Error: Unkown command $cmd"
     exit 1
     ;;
 esac

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+# This script uses cras_test_client to present an interface similar to the
+# brightness script for crouton.
+
+# The MIT License (MIT)
+# 
+# Copyright (c) 2015 Samuel Dionne-Riel
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+set -e
+set -u
+
+DEFAULT_VOLUME_DELTA=5
+
+get_current_output() {
+	cras_test_client --dump_server_info | grep -i 'Selected Output Node' | \
+		sed -e 's#[[:space:]]*##g' | sed -e 's#^[a-zA-Z]*:##'
+}
+
+get_current_output_infos() {
+	cras_test_client --dump_server_info | grep $(get_current_output) | grep '^	'
+}
+
+get_current_volume() {
+	get_current_output_infos | cut -d'	' -f3 | sed -e 's# *##' | cut -d' ' -f1
+}
+set_volume() {
+	local volume=$1
+	# Clamp volume to zero
+	# A negative amount of absolute volume sets it to 100%
+	if (( volume < 0 )); then
+		volume=0
+	fi
+	cras_test_client --set_node_volume $(get_current_output):$volume
+}
+
+get_is_muted() {
+	local counter=0
+	local is_muted=""
+	host-dbus dbus-send --print-reply --system \
+		--dest=org.chromium.cras --type=method_call \
+		/org/chromium/cras org.chromium.cras.Control.GetVolumeState \
+		| while read line ; do
+		# We want the fifth value.
+		if [[ "$counter" == "5" ]]; then
+			is_muted=$(echo $line | cut -d' ' -f2-)
+			echo $is_muted
+		fi
+		(( counter++ ))||:
+	done
+}
+
+toggle_mute() {
+	if [[ $(get_is_muted) == "true" ]]; then
+		unmute
+	else
+		mute
+	fi
+	exit 0
+}
+
+mute() {
+	cras_test_client --user_mute 1
+}
+unmute() {
+	cras_test_client --user_mute 0
+}
+
+relative_volume() {
+	local delta=$1
+	# FIXME : When muted, set to zero if relative is going down.
+	# We cannot currently get the proper mute state.
+	# FIXME : When unmuting, should only unmute and not adjust.
+	if [[ $(get_is_muted) == "true" ]]; then
+		unmute
+		if (( delta < 0 )); then
+			set_volume 0
+		fi
+	else
+		set_volume $(( $(get_current_volume) + $delta ))
+	fi
+}
+
+print_help() {
+	echo "Usage: $(basename $0) [set|up|down|mute|0-100]"
+	echo "   up/down can receive an amount value to increase/decrease."
+	echo "   mute can receive commands set|unset."
+	echo "   set take a value between 0 and 100."
+	echo ""
+	echo "Shortcut invocations:"
+	echo "  $(basename $0) up     increases by $DEFAULT_VOLUME_DELTA"
+	echo "  $(basename $0) down   decreases by $DEFAULT_VOLUME_DELTA"
+	echo "  $(basename $0) mute   sets muted"
+	echo "  $(basename $0) 0-100  sets volume to given value"
+}
+
+if [[ $# -lt 1 ]]; then
+	print_help
+	exit 0
+fi
+
+cmd=$1
+
+if [[ "$cmd" == "up" ]]; then
+	relative_volume ${2-$DEFAULT_VOLUME_DELTA}
+	exit 0
+elif [[ "$cmd" == "down" ]]; then
+	relative_volume "-${2-$DEFAULT_VOLUME_DELTA}"
+	exit 0
+elif [[ "$cmd" == "mute" ]]; then
+	# Toggle cannot be used right now.
+	action="${2-set}"
+	if [[ "$action" == "toggle" ]]; then
+		toggle_mute
+	elif [[ "$action" == "set" ]]; then
+		mute
+	elif [[ "$action" == "unset" ]]; then
+		unmute
+	else
+		echo "Invalid action: $action for mute."
+		print_help
+		exit 1
+	fi
+	exit 0
+elif [[ "$cmd" == "set" ]]; then
+	shift
+fi
+
+if [[ $# -lt 1 ]]; then
+	echo "set needs an amount to set."
+	print_help
+	exit 1
+fi
+
+set_volume $1

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -82,7 +82,6 @@ set_volume() {
 }
 
 get_is_muted() {
-    local counter=0
     local muted="$(host-dbus dbus-send --print-reply --system \
         --dest=org.chromium.cras --type=method_call \
         /org/chromium/cras org.chromium.cras.Control.GetVolumeState \
@@ -113,7 +112,7 @@ relative_volume() {
             set_volume 0
         fi
     else
-        set_volume "$(( $(get_current_volume) + $delta ))"
+        set_volume "$(( $(get_current_volume) + delta ))"
     fi
 }
 
@@ -145,7 +144,7 @@ shift
 if [ "$cmd" = "help" ] || [ "$cmd" = "-h" ] || [ "$cmd" = "--help" ]; then
     print_help
 elif [ "$cmd" = "up" ]; then
-    relative_volume ${2-$DEFAULT_VOLUME_DELTA}
+    relative_volume "${2-$DEFAULT_VOLUME_DELTA}"
 elif [ "$cmd" = "down" ]; then
     relative_volume "-${2-$DEFAULT_VOLUME_DELTA}"
 elif [ "$cmd" = "mute" ]; then
@@ -168,10 +167,10 @@ elif [ "$cmd" = "set" ]; then
         print_help
         exit 1
     fi
-    set_volume $1
+    set_volume "$1"
 elif [ "$cmd" -eq "$cmd" ] 2>/dev/null; then
     # Previous test tests for integer-ish value
-    set_volume $cmd
+    set_volume "$cmd"
 else
     print_help
 fi

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -1,178 +1,158 @@
 #!/bin/sh
-
-# This script uses cras_test_client to present an interface similar to the
-# brightness script for crouton.
-
 # Copyright (c) 2015 The crouton Authors. All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-#    * Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#    * Redistributions in binary form must reproduce the above
-# copyright notice, this list of conditions and the following disclaimer
-# in the documentation and/or other materials provided with the
-# distribution.
-#    * Neither the name of Google Inc. nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This script uses amixer to present an interface similar to the
+# brightness script for crouton.
 
 set -e
 set -u
 
 DEFAULT_VOLUME_DELTA=5
 
-get_current_output() {
-    # This function gets the current Output Node ID (x:y)
+APPLICATION="${0##*/}"
+USAGE="$APPLICATION [set] [0-100]
+$APPLICATION up|down [0-100]
+$APPLICATION mute [set|unset|toggle]
 
-    # From cras_test_client we can get the current output node from
-    # a specific line. This sed pipeline extracts it.
-    # The line looks like this:
-    #     Selected Output Node: 7:1
-    cras_test_client --dump_server_info | sed -n \
-        -e '/Selected Output Node/s#[[:space:]]*##g;s#^[a-zA-Z]*:##p'
-    #       ^                     ^                 ^              ^ print
-    #       ^                     ^                 ^ substitute letters
-    #       ^                     ^ substitude spaces for nothing
-    #       ^ select this line only
-}
+This script changes the volume of the current output
+device, as would changing it with the shortcut keys or
+with the GUI in Chrome OS.
 
-get_current_output_infos() {
-    # This function gets line from cras_test_client --dump_server_info that 
-    # represents the current state of the current output.
+Shortcut invocations:
+    $APPLICATION up     increases by $DEFAULT_VOLUME_DELTA
+    $APPLICATION down   decreases by $DEFAULT_VOLUME_DELTA
+    $APPLICATION mute   sets muted
+    $APPLICATION 0-100  sets volume to given value
+"
+# The control which controls the current output.
+ALSA_CONTROL="Master"
 
-    # The current output informations will not duplicate an output node, this makes
-    # it safe(-ish) to filter out on the current output ID.
-    # This would also select the "Selected Output Node" line, but by filtering the
-    # lines beginning with space characters, this selects the proper line.
-    # If for any reason this starts failing, it could be replaced with a sed script
-    # that acts only between the two "headers" "Output Nodes" and "Input Devices".
-    cras_test_client --dump_server_info | grep "^[[:space:]].*$(get_current_output)"
-}
-
-get_current_volume() {
-    get_current_output_infos | sed -e \
-        "s#[[:space:]]\+#;#g" | cut -d';' -f3
-    #    ^                        ^ Use cut to get the third field (Volume)
-    #    ^ normalize spaces/tab separators to semicolons
+# Tiny sugar coating around amixer for common parameters.
+_amixer() {
+    amixer -Dcras "$@"
 }
 
 set_volume() {
     local volume="$1"
-    # Clamp volume to zero
-    # A negative amount of absolute volume sets it to 100%
-    if [ "$volume" -lt 0 ] ; then
-        volume=0
-    fi
-    cras_test_client --set_node_volume "$(get_current_output):$volume"
+    _amixer -q sset $ALSA_CONTROL "$volume"
 }
 
 get_is_muted() {
-    local muted="$(host-dbus dbus-send --print-reply --system \
-        --dest=org.chromium.cras --type=method_call \
-        /org/chromium/cras org.chromium.cras.Control.GetVolumeState \
-        | sed -n -e '6s/.*boolean[[:space:]]\+//p')"
-    [ "$muted" = "true" ]
-}
+    # Get the alsa state of the control.
+    local state="$(_amixer sget $ALSA_CONTROL \
+        | sed -n -e '$s/[[:space:]]\+/;/gp' | cut -d';' -f6 )"
+    #                ^     ^                   ^ Get the sixth field.
+    #                ^     ^ Normalize spaces to one semicolon
+    #                ^ Work only on the last line
 
-toggle_mute() {
-    if get_is_muted; then
-        unmute
+    # Muted is [off] (control is off)
+    if [ "$state" = "[on]" ]; then
+        # Is not muted, so is_muted is false
+        return 1
     else
-        mute
+        # Is muted, so is_muted is true
+        return 0
     fi
 }
 
+toggle_mute() {
+    _amixer -q sset $ALSA_CONTROL toggle
+}
+
 mute() {
-    cras_test_client --user_mute 1
+    _amixer -q sset $ALSA_CONTROL mute
 }
 unmute() {
-    cras_test_client --user_mute 0
+    _amixer -q sset $ALSA_CONTROL unmute
 }
 
 relative_volume() {
     local delta="$1"
     if get_is_muted; then
-        unmute
         if [ "$delta" -lt 0 ]; then
             set_volume 0
         fi
+        unmute
     else
-        set_volume "$(( $(get_current_volume) + delta ))"
+        # Is the volume going down or up?
+        if [ "$delta" -lt 0 ]; then
+            # Down, then we need to make that number positive
+            : $(( delta=delta * -1 ))
+            # And suffix the minus sign.
+            set_volume "${delta}-"
+        else
+            # Only suffix the plus sign.
+            set_volume "${delta}+"
+        fi
     fi
 }
 
 print_help() {
-    local script="$(basename "$0")"
-    echo "$script [set] [0-100]"
-    echo "$script up|down [0-100]"
-    echo "$script mute [set|unset|toggle]"
-    echo ""
-    echo "This script changes the volume of the current output"
-    echo "device, as would changing it with the shortcut keys or"
-    echo "with the GUI in Chrome OS."
-    echo ""
-    echo "Shortcut invocations:"
-    echo "  $script up     increases by $DEFAULT_VOLUME_DELTA"
-    echo "  $script down   decreases by $DEFAULT_VOLUME_DELTA"
-    echo "  $script mute   sets muted"
-    echo "  $script 0-100  sets volume to given value"
+    # Prints the usage message.
+    # Can also get a message to show first.
+    [ $# -gt 0 ] && echo "$@"
+    echo "$USAGE"
 }
 
 if [ $# -lt 1 ]; then
-    print_help
-    exit 0
+    print_help "Error: $APPLICATION needs at least a command." 1>&2
+    exit 1
 fi
 
 cmd="$1"
 shift
 
-if [ "$cmd" = "help" ] || [ "$cmd" = "-h" ] || [ "$cmd" = "--help" ]; then
+case "$cmd" in
+h*|-h*|--help)
     print_help
-elif [ "$cmd" = "up" ]; then
-    relative_volume "${2-$DEFAULT_VOLUME_DELTA}"
-elif [ "$cmd" = "down" ]; then
-    relative_volume "-${2-$DEFAULT_VOLUME_DELTA}"
-elif [ "$cmd" = "mute" ]; then
-    # Toggle cannot be used right now.
+    ;;
+up)
+    relative_volume "${1-$DEFAULT_VOLUME_DELTA}"
+    ;;
+down)
+    relative_volume "-${1-$DEFAULT_VOLUME_DELTA}"
+    ;;
+mute)
     action="${1-set}"
-    if [ "$action" = "toggle" ]; then
+    case "$action" in
+    "toggle")
         toggle_mute
-    elif [ "$action" = "set" ]; then
+        ;;
+    set)
         mute
-    elif [ "$action" = "unset" ]; then
+        ;;
+    unset)
         unmute
-    else
-        echo "Invalid action: $action for mute."
-        print_help
+        ;;
+    *)
+        print_help "Invalid action: $action for mute." 1>&2
+        exit 1
+        ;;
+    esac
+    ;;
+set|[0-9]|[0-9][0-9]|100)
+    amount="$cmd"
+    # First, check that we received a value to set the volume to.
+    if [ $# -eq 0 ] && [ "$cmd" = "set" ]; then
+        print_help "Error: $APPLICATION set needs an amount to set." 1>&2
         exit 1
     fi
-elif [ "$cmd" = "set" ]; then
-    if [ $# -lt 1 ]; then
-        echo "set needs an amount to set."
-        print_help
+    # The value /could/ have been a parameter or the command itself.
+    if [ $# -gt 0 ]; then
+        amount="$1"
+        shift
+    fi
+    # Check that this is integer-ish enough.
+    if ! [ "$amount" -eq "$amount" ] 2>/dev/null; then
+        print_help "Error: $APPLICATION set needs a number [0-100]" 1>&2
         exit 1
     fi
-    set_volume "$1"
-elif [ "$cmd" -eq "$cmd" ] 2>/dev/null; then
-    # Previous test tests for integer-ish value
-    set_volume "$cmd"
-else
-    print_help
-fi
-
-# vim: noai:ts=4:sw=4:expandtab
+    set_volume "$amount"
+    ;;
+*)
+    print_help "Error: Unkown command $cmd" 1>&2
+    exit 1
+    ;;
+esac

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -122,6 +122,16 @@ error_help() {
     print_help 1>&2
 }
 
+# Do a sanity check with amixer.
+# An out of date crouton chroot might exhibit problems like:
+#     amixer: Control cras element read error: Input/output error
+# We cannot do it in _amixer since it's executed in a subshell and its value is
+# used as a substitution.
+if ! _amixer > /dev/null 2>&1; then
+    echo "Failed to communicate with the audio server. Please update your chroot." 1>&2
+    exit 2
+fi
+
 if [ $# -lt 1 ]; then
     error_help "Error: $APPLICATION needs at least a command."
     exit 1

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -1,29 +1,35 @@
-#!/bin/bash
+#!/bin/sh
 
 # This script uses cras_test_client to present an interface similar to the
 # brightness script for crouton.
 
-# The MIT License (MIT)
-# 
-# Copyright (c) 2015 Samuel Dionne-Riel
-# 
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Copyright (c) 2015 The crouton Authors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -e
 set -u
@@ -31,123 +37,143 @@ set -u
 DEFAULT_VOLUME_DELTA=5
 
 get_current_output() {
-	cras_test_client --dump_server_info | grep -i 'Selected Output Node' | \
-		sed -e 's#[[:space:]]*##g' | sed -e 's#^[a-zA-Z]*:##'
+    # This function gets the current Output Node ID (x:y)
+
+    # From cras_test_client we can get the current output node from
+    # a specific line. This sed pipeline extracts it.
+    # The line looks like this:
+    #     Selected Output Node: 7:1
+    cras_test_client --dump_server_info | sed -n \
+        -e '/Selected Output Node/s#[[:space:]]*##g;s#^[a-zA-Z]*:##p'
+    #       ^                     ^                 ^              ^ print
+    #       ^                     ^                 ^ substitute letters
+    #       ^                     ^ substitude spaces for nothing
+    #       ^ select this line only
 }
 
 get_current_output_infos() {
-	cras_test_client --dump_server_info | grep $(get_current_output) | grep '^	'
+    # This function gets line from cras_test_client --dump_server_info that 
+    # represents the current state of the current output.
+
+    # The current output informations will not duplicate an output node, this makes
+    # it safe(-ish) to filter out on the current output ID.
+    # This would also select the "Selected Output Node" line, but by filtering the
+    # lines beginning with space characters, this selects the proper line.
+    # If for any reason this starts failing, it could be replaced with a sed script
+    # that acts only between the two "headers" "Output Nodes" and "Input Devices".
+    cras_test_client --dump_server_info | grep "^[[:space:]].*$(get_current_output)"
 }
 
 get_current_volume() {
-	get_current_output_infos | cut -d'	' -f3 | sed -e 's# *##' | cut -d' ' -f1
+    get_current_output_infos | sed -e \
+        "s#[[:space:]]\+#;#g" | cut -d';' -f3
+    #    ^                        ^ Use cut to get the third field (Volume)
+    #    ^ normalize spaces/tab separators to semicolons
 }
+
 set_volume() {
-	local volume=$1
-	# Clamp volume to zero
-	# A negative amount of absolute volume sets it to 100%
-	if (( volume < 0 )); then
-		volume=0
-	fi
-	cras_test_client --set_node_volume $(get_current_output):$volume
+    local volume="$1"
+    # Clamp volume to zero
+    # A negative amount of absolute volume sets it to 100%
+    if [ "$volume" -lt 0 ] ; then
+        volume=0
+    fi
+    cras_test_client --set_node_volume "$(get_current_output):$volume"
 }
 
 get_is_muted() {
-	local counter=0
-	local is_muted=""
-	host-dbus dbus-send --print-reply --system \
-		--dest=org.chromium.cras --type=method_call \
-		/org/chromium/cras org.chromium.cras.Control.GetVolumeState \
-		| while read line ; do
-		# We want the fifth value.
-		if [[ "$counter" == "5" ]]; then
-			is_muted=$(echo $line | cut -d' ' -f2-)
-			echo $is_muted
-		fi
-		(( counter++ ))||:
-	done
+    local counter=0
+    local muted="$(host-dbus dbus-send --print-reply --system \
+        --dest=org.chromium.cras --type=method_call \
+        /org/chromium/cras org.chromium.cras.Control.GetVolumeState \
+        | sed -n -e '6s/.*boolean[[:space:]]\+//p')"
+    [ "$muted" = "true" ]
 }
 
 toggle_mute() {
-	if [[ $(get_is_muted) == "true" ]]; then
-		unmute
-	else
-		mute
-	fi
-	exit 0
+    if get_is_muted; then
+        unmute
+    else
+        mute
+    fi
 }
 
 mute() {
-	cras_test_client --user_mute 1
+    cras_test_client --user_mute 1
 }
 unmute() {
-	cras_test_client --user_mute 0
+    cras_test_client --user_mute 0
 }
 
 relative_volume() {
-	local delta=$1
-	# FIXME : When muted, set to zero if relative is going down.
-	# We cannot currently get the proper mute state.
-	# FIXME : When unmuting, should only unmute and not adjust.
-	if [[ $(get_is_muted) == "true" ]]; then
-		unmute
-		if (( delta < 0 )); then
-			set_volume 0
-		fi
-	else
-		set_volume $(( $(get_current_volume) + $delta ))
-	fi
+    local delta="$1"
+    if get_is_muted; then
+        unmute
+        if [ "$delta" -lt 0 ]; then
+            set_volume 0
+        fi
+    else
+        set_volume "$(( $(get_current_volume) + $delta ))"
+    fi
 }
 
 print_help() {
-	echo "Usage: $(basename $0) [set|up|down|mute|0-100]"
-	echo "   up/down can receive an amount value to increase/decrease."
-	echo "   mute can receive commands set|unset."
-	echo "   set take a value between 0 and 100."
-	echo ""
-	echo "Shortcut invocations:"
-	echo "  $(basename $0) up     increases by $DEFAULT_VOLUME_DELTA"
-	echo "  $(basename $0) down   decreases by $DEFAULT_VOLUME_DELTA"
-	echo "  $(basename $0) mute   sets muted"
-	echo "  $(basename $0) 0-100  sets volume to given value"
+    local script="$(basename "$0")"
+    echo "$script [set] [0-100]"
+    echo "$script up|down [0-100]"
+    echo "$script mute [set|unset|toggle]"
+    echo ""
+    echo "This script changes the volume of the current output"
+    echo "device, as would changing it with the shortcut keys or"
+    echo "with the GUI in Chrome OS."
+    echo ""
+    echo "Shortcut invocations:"
+    echo "  $script up     increases by $DEFAULT_VOLUME_DELTA"
+    echo "  $script down   decreases by $DEFAULT_VOLUME_DELTA"
+    echo "  $script mute   sets muted"
+    echo "  $script 0-100  sets volume to given value"
 }
 
-if [[ $# -lt 1 ]]; then
-	print_help
-	exit 0
+if [ $# -lt 1 ]; then
+    print_help
+    exit 0
 fi
 
-cmd=$1
+cmd="$1"
+shift
 
-if [[ "$cmd" == "up" ]]; then
-	relative_volume ${2-$DEFAULT_VOLUME_DELTA}
-	exit 0
-elif [[ "$cmd" == "down" ]]; then
-	relative_volume "-${2-$DEFAULT_VOLUME_DELTA}"
-	exit 0
-elif [[ "$cmd" == "mute" ]]; then
-	# Toggle cannot be used right now.
-	action="${2-set}"
-	if [[ "$action" == "toggle" ]]; then
-		toggle_mute
-	elif [[ "$action" == "set" ]]; then
-		mute
-	elif [[ "$action" == "unset" ]]; then
-		unmute
-	else
-		echo "Invalid action: $action for mute."
-		print_help
-		exit 1
-	fi
-	exit 0
-elif [[ "$cmd" == "set" ]]; then
-	shift
+if [ "$cmd" = "help" ] || [ "$cmd" = "-h" ] || [ "$cmd" = "--help" ]; then
+    print_help
+elif [ "$cmd" = "up" ]; then
+    relative_volume ${2-$DEFAULT_VOLUME_DELTA}
+elif [ "$cmd" = "down" ]; then
+    relative_volume "-${2-$DEFAULT_VOLUME_DELTA}"
+elif [ "$cmd" = "mute" ]; then
+    # Toggle cannot be used right now.
+    action="${1-set}"
+    if [ "$action" = "toggle" ]; then
+        toggle_mute
+    elif [ "$action" = "set" ]; then
+        mute
+    elif [ "$action" = "unset" ]; then
+        unmute
+    else
+        echo "Invalid action: $action for mute."
+        print_help
+        exit 1
+    fi
+elif [ "$cmd" = "set" ]; then
+    if [ $# -lt 1 ]; then
+        echo "set needs an amount to set."
+        print_help
+        exit 1
+    fi
+    set_volume $1
+elif [ "$cmd" -eq "$cmd" ] 2>/dev/null; then
+    # Previous test tests for integer-ish value
+    set_volume $cmd
+else
+    print_help
 fi
 
-if [[ $# -lt 1 ]]; then
-	echo "set needs an amount to set."
-	print_help
-	exit 1
-fi
-
-set_volume $1
+# vim: noai:ts=4:sw=4:expandtab

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -41,14 +41,16 @@ set_volume() {
 
 get_is_muted() {
     # Get the alsa state of the control.
-    local state="$(_amixer sget $ALSA_CONTROL \
-        | sed -n -e '$s/[[:space:]]\+/;/gp' | cut -d';' -f6 )"
-    #                ^     ^                   ^ Get the sixth field.
-    #                ^     ^ Normalize spaces to one semicolon
-    #                ^ Work only on the last line
+    local state="$(_amixer contents | sed -n \
+        -e "/^numid.*name=.$ALSA_CONTROL Playback Switch/,/^numid/{/[[:space:]]\+:/s/.*=//p}")"
+    #        ^                                             ^      ^ ^              ^      ^ Print the line.
+    #        ^                                             ^      ^ ^              ^ Replace everything before the equal sign.
+    #        ^                                             ^      ^ ^ Search for the line with spaces and a colon (the value).
+    #        ^                                             ^      ^ On that selection:
+    #        ^---------------------------------------------^ Select from first group to next group.
 
-    # Muted is [off] (control is off)
-    if [ "$state" = "[on]" ]; then
+    # Muted is off (control is off)
+    if [ "$state" = "on" ]; then
         # Is not muted, so is_muted is false
         return 1
     else

--- a/chroot-bin/volume
+++ b/chroot-bin/volume
@@ -41,13 +41,11 @@ set_volume() {
 
 get_is_muted() {
     # Get the alsa state of the control.
-    local state="$(_amixer contents | sed -n \
-        -e "/^numid.*name=.$ALSA_CONTROL Playback Switch/,/^numid/{/[[:space:]]\+:/s/.*=//p}")"
-    #        ^                                             ^      ^ ^              ^      ^ Print the line.
-    #        ^                                             ^      ^ ^              ^ Replace everything before the equal sign.
-    #        ^                                             ^      ^ ^ Search for the line with spaces and a colon (the value).
-    #        ^                                             ^      ^ On that selection:
-    #        ^---------------------------------------------^ Select from first group to next group.
+    local state="$(_amixer cget "name=$ALSA_CONTROL Playback Switch" | sed -n \
+        -e "/[[:space:]]\+:/s/.*=//p")"
+    #       ^              ^      ^ Print the line.
+    #       ^              ^ Replace everything before the equal sign.
+    #       ^ Search for the line with spaces and a colon (the value).
 
     # Muted is off (control is off)
     if [ "$state" = "on" ]; then

--- a/targets/audio
+++ b/targets/audio
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 REQUIRES='core'
 DESCRIPTION='Support audio playback via Chromium OS'\''s audio system.'
+CHROOTBIN='volume'
 CHROOTETC='pulseaudio-default.pa'
 . "${TARGETSDIR:="$PWD"}/common"
 


### PR DESCRIPTION
This script interfaces with same volume slider that Chrome OS uses.
It has been tested on a C720p, but not with HDMI output.

There is an issue currently with this script:
  * The status of the volume chrome-side is not updated. This means that lowering the volume in crouton, then switching to Chrome OS, then lowering it again will reset it at first to where it was the last time it was changed in Chrome OS.

This script is far from minimal, it uses some ugly command pipes to get status informations, but it works and should be solid.

It might be a good idea to build a native cras client that does this by itself instead of relying on the test utility and the dbus interface.