### PR TITLE
Fix for issue #1558 - Search key mappings in Freon

### DIFF
--- a/src/fbserver-proto.h
+++ b/src/fbserver-proto.h
@@ -81,6 +81,12 @@ struct  __attribute__((__packed__)) mousemove {
     uint16_t y;
 };
 
+/* Send initialization info */
+struct  __attribute__((__packed__)) initinfo {
+    char type; /* I */
+    uint8_t freon; /* 0: not using freon, 1: using freon */
+};
+
 /* Click the mouse */
 struct  __attribute__((__packed__)) mouseclick {
     char type;  /* 'C' */

--- a/src/fbserver-proto.h
+++ b/src/fbserver-proto.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 
 /* WebSocket constants */
-#define VERSION "VF2"
+#define VERSION "VF3"
 #define PORT_BASE 30010
 
 /* Request for a frame */

--- a/src/fbserver.c
+++ b/src/fbserver.c
@@ -492,12 +492,12 @@ int write_cursor() {
 }
 
 void write_init() {
-    struct stat _stat;
+    struct stat stat_buf;
     char raw[FRAMEMAXHEADERSIZE + sizeof(struct initinfo)];
     struct initinfo* i = (struct initinfo*)(raw + FRAMEMAXHEADERSIZE);
     i->type = 'I';
     i->freon = 0;
-    if (stat("/sys/class/tty/tty0/active", &_stat) == -1) {
+    if (stat("/sys/class/tty/tty0/active", &stat_buf) == -1) {
         trueorabort(errno == ENOENT, "Could not determine if using Freon or not");
         i->freon = 1;
     }

--- a/src/fbserver.c
+++ b/src/fbserver.c
@@ -492,12 +492,11 @@ int write_cursor() {
 }
 
 void write_init() {
-    struct stat stat_buf;
     char raw[FRAMEMAXHEADERSIZE + sizeof(struct initinfo)];
     struct initinfo* i = (struct initinfo*)(raw + FRAMEMAXHEADERSIZE);
     i->type = 'I';
     i->freon = 0;
-    if (stat("/sys/class/tty/tty0/active", &stat_buf) == -1) {
+    if (access("/sys/class/tty/tty0/active", F_OK) == -1) {
         trueorabort(errno == ENOENT, "Could not determine if using Freon or not");
         i->freon = 1;
     }

--- a/src/fbserver.c
+++ b/src/fbserver.c
@@ -491,6 +491,19 @@ int write_cursor() {
     return 0;
 }
 
+void write_init() {
+    struct stat _stat;
+    char raw[FRAMEMAXHEADERSIZE + sizeof(struct initinfo)];
+    struct initinfo* i = (struct initinfo*)(raw + FRAMEMAXHEADERSIZE);
+    i->type = 'I';
+    i->freon = 0;
+    if (stat("/sys/class/tty/tty0/active", &_stat) == -1) {
+        trueorabort(errno == ENOENT, "Could not determine if using Freon or not");
+        i->freon = 1;
+    }
+    socket_client_write_frame(raw, sizeof(*i), WS_OPCODE_BINARY, 1);
+}
+
 /* Checks if a packet size is correct */
 int check_size(int length, int target, char* error) {
     if (length != target) {
@@ -540,6 +553,7 @@ int main(int argc, char** argv) {
     while (1) {
         set_connected(dpy, False);
         socket_server_accept(VERSION);
+        write_init();
         set_connected(dpy, True);
         while (1) {
             length = socket_client_read_frame((char*)buffer, sizeof(buffer));


### PR DESCRIPTION
croutonfbserver now sends information to kiwi nacl module on startup regarding whether we are using Freon or not. The nacl module uses different key schemes depending on whether Freon is used or not, enabling SearchKey + otherkey mappings to work correctly for both freon and non-freon users.