### PR TITLE
Input-related settings no longer blocked on Freon

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -87,12 +87,17 @@ fi
 # Launch system-wide trigger daemon
 croutontriggerd &
 
-# Input-related stuff is not needed for kiwi
-if [ "$xmethodtype" != "xiwi" ]; then
+
+# Apply the Chromebook keyboard map. Not needed for xiwi with the exception of Freon.
+if [ "$xmethodtype" != 'xiwi' ] || [ ! -f "/sys/class/tty/tty0/active" ]; then
     # Apply the Chromebook keyboard map if installed.
     if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
         setxkbmap -model chromebook
     fi
+fi
+
+# Input-related stuff is not needed for kiwi
+if [ "$xmethodtype" != "xiwi" ]; then
 
     # Launch X-server-local key binding daemon
     xbindkeys -fg /etc/crouton/xbindkeysrc.scm
@@ -125,15 +130,6 @@ if [ "$xmethodtype" != "xiwi" ]; then
         done
     fi
 fi
-
-# Apply the Chromebook keyboard map in xiwi if using Freon. 
-if [ "$xmethodtype" = 'xiwi' ] && [ ! -f "/sys/class/tty/tty0/active" ]; then
-    # Apply the Chromebook keyboard map if installed.
-    if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
-        setxkbmap -model chromebook
-    fi
-fi
-
 
 # Crouton-in-a-tab: Start fbserver and launch display
 if [ "$xmethodtype" = 'xiwi' ]; then

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -88,7 +88,7 @@ fi
 croutontriggerd &
 
 # Input-related stuff is not needed for kiwi, unless we are using Freon which sends raw input
-if [ "$xmethodtype" != "xiwi" ] || [ ! -f "/sys/class/tty/tty0/active" ]; then
+if [ "$xmethodtype" != "xiwi" ]; then
     # Apply the Chromebook keyboard map if installed.
     if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
         setxkbmap -model chromebook
@@ -125,6 +125,16 @@ if [ "$xmethodtype" != "xiwi" ] || [ ! -f "/sys/class/tty/tty0/active" ]; then
         done
     fi
 fi
+
+# Apply the Chromebook keyboard map if using Freon. 
+# TODO: Add more Freon specific xiwi stuff when the need arises
+if [ "$xmethodtype" == "xiwi" ] || [ ! -f "/sys/class/tty/tty0/active" ]; then
+    # Apply the Chromebook keyboard map if installed.
+    if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
+        setxkbmap -model chromebook
+    fi
+fi
+
 
 # Crouton-in-a-tab: Start fbserver and launch display
 if [ "$xmethodtype" = 'xiwi' ]; then

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -126,9 +126,8 @@ if [ "$xmethodtype" != "xiwi" ]; then
     fi
 fi
 
-# Apply the Chromebook keyboard map if using Freon. 
-# TODO: Add more Freon specific xiwi stuff when the need arises
-if [ "$xmethodtype" == "xiwi" ] || [ ! -f "/sys/class/tty/tty0/active" ]; then
+# Apply the Chromebook keyboard map in xiwi if using Freon. 
+if [ "$xmethodtype" = 'xiwi' ] && [ ! -f "/sys/class/tty/tty0/active" ]; then
     # Apply the Chromebook keyboard map if installed.
     if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
         setxkbmap -model chromebook

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -87,7 +87,7 @@ fi
 # Launch system-wide trigger daemon
 croutontriggerd &
 
-# Input-related stuff is not needed for kiwi, unless we are using Freon which sends raw input
+# Input-related stuff is not needed for kiwi
 if [ "$xmethodtype" != "xiwi" ]; then
     # Apply the Chromebook keyboard map if installed.
     if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -87,8 +87,8 @@ fi
 # Launch system-wide trigger daemon
 croutontriggerd &
 
-# Input-related stuff is not needed for kiwi
-if [ "$xmethodtype" != "xiwi" ]; then
+# Input-related stuff is not needed for kiwi, unless we are using Freon which sends raw input
+if [ "$xmethodtype" != "xiwi" ] || [ ! -f "/sys/class/tty/tty0/active" ]; then
     # Apply the Chromebook keyboard map if installed.
     if [ -f '/usr/share/X11/xkb/compat/chromebook' ]; then
         setxkbmap -model chromebook


### PR DESCRIPTION
Fix for issue #1558 where the `chromebook` keyboard model is not chosen at startup when using xiwi.

For non-Freon users using xiwi, no input settings (like the use of the chromebook keyboard model) are needed because the ChromeOS performs the keymapping before sending them to the window.

But for Freon users, ChromeOS does not perform this keymapping and instead sends the actual keypresses, again requiring the use of the input settings.

Changed the if statement so that it ignores setting input-related stuff only if using xiwi and not using freon.