### PR TITLE
Force-yes when doing dist-upgrade

### DIFF
--- a/targets/core
+++ b/targets/core
@@ -103,7 +103,7 @@ EOF
     apt-get -y update || true
 
     echo 'Ensuring system is up-to-date...' 1>&2
-    apt-get -y dist-upgrade
+    apt-get -y --force-yes dist-upgrade
 fi
 
 # On release upgrade, keyboard-configuration might be reconfigured.


### PR DESCRIPTION
If users installed some packages from PPA that cannot be authenticated, the
original ```apt-get -y dist-upgrade``` will stop working, returning an error: ```There
are problems and -y was used without --force-yes```.

I personally installed newer version of xfce4 from PPA and got this error.