### PR TITLE
Improved bootstrapping

### DIFF
--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -60,9 +60,15 @@ chmod 755 "$tmp/ar" "$tmp/pkgdetails"
 # want any files there. Create an empty tarball that it can extract.
 tar -czf "$tmp/devices.tar.gz" -T /dev/null
 
+# There is no bootstrap script for some distros derived from Debian. Thus we use
+# the scripts for matching upstream distros to bootstrap the derived distros.
+if [ ! -f "$tmp/scripts/$RELEASE" ]; then
+        ln -s "$tmp/scripts/$BOOTSTRAP_RELEASE" "$tmp/scripts/$RELEASE"
+fi
+
 # Grab the release and drop it into the subdirectory
 echo 'Downloading bootstrap files...' 1>&2
 PATH="$newpath" DEBOOTSTRAP_DIR="$tmp" $FAKEROOT \
     "$tmp/debootstrap" --foreign --arch="$ARCH" \
-    "${BOOTSTRAP_RELEASE:-"$RELEASE"}" \
-                       "$tmp/$subdir" "$MIRROR" 1>&2
+    "$RELEASE" "$tmp/$subdir" "$MIRROR" 1>&2
+


### PR DESCRIPTION
This patch comes up because the directory structure of http.kali.org has changed. There is no directory called ```stable``` anymore. It is substituted by ```kali/```. However I think this can be a universal improvement as the implementation of bootstrapping kali we have currently only works for kali, not for other derived distros.

This fix has been part of my effort to add the Trisquel distro and it has been sleeping in [my fork](https://github.com/tonyxue/cruise/tree/trisquel) for quite a long time now. :P 

Fixed according to #1868 