### PR TITLE
Lookup release name correctly. Fixes #1880.

### DIFF
--- a/installer/ubuntu/getrelease.sh
+++ b/installer/ubuntu/getrelease.sh
@@ -18,8 +18,11 @@ if [ ! -s "$sources" ]; then
     exit 1
 fi
 
-rel="`awk '/^deb .* main( .*)?$/ { print $3; exit }' \
-          "$sources" "$sources.d"/*.list 2>/dev/null`"
+rel="`awk '/^deb .* main( .*)?$/ \
+    { for ( i = 1; i <= NF; i++ ) \
+    { if ( $i~/http|file|cdrom|ftp|copy|rsh|ssh/ ) \
+    { i++; print $i; exit } } }' \
+    "$sources" "$sources.d"/*.list 2>/dev/null`"
 if [ -z "$rel" ] || \
         ! grep -q "^$rel\([^a-z].*\)*$" "`dirname "$0"`/releases"; then
     exit 1

--- a/installer/ubuntu/getrelease.sh
+++ b/installer/ubuntu/getrelease.sh
@@ -18,11 +18,10 @@ if [ ! -s "$sources" ]; then
     exit 1
 fi
 
-rel="`awk '/^deb .* main( .*)?$/ \
-    { for ( i = 1; i <= NF; i++ ) \
-    { if ( $i~/http|file|cdrom|ftp|copy|rsh|ssh/ ) \
-    { i++; print $i; exit } } }' \
-    "$sources" "$sources.d"/*.list 2>/dev/null`"
+# Lookup the release name from the field after the URI
+# We identify URI by '://'
+rel="`sed -n 's|^deb .*://[^ ]* \([^ ]*\) main\( .*\)\?$|\1|p' \
+    "$sources" "$sources.d"/*.list | head -n 1`"
 if [ -z "$rel" ] || \
         ! grep -q "^$rel\([^a-z].*\)*$" "`dirname "$0"`/releases"; then
     exit 1


### PR DESCRIPTION
getrelease.sh now looks up release name after the URI of one of the types
specified in the [man page](http://manpages.debian.org/cgi-bin/man.cgi?sektion=5&query=sources.list&apropos=0&manpath=sid&locale=en).

Fixes #1880 