### PR TITLE
Use http redirector by default to access the Debian archive

### DIFF
--- a/installer/debian/defaults
+++ b/installer/debian/defaults
@@ -18,7 +18,7 @@ arm*) ARCH="armhf";;
 esac
 
 if [ -z "$MIRROR" ]; then
-    MIRROR="${CROUTON_MIRROR_debian:-http://ftp.debian.org/debian/}"
+    MIRROR="${CROUTON_MIRROR_debian:-http://httpredir.debian.org/debian/}"
 fi
 
 if [ -z "$MIRROR2" ]; then

--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -14,7 +14,7 @@ d='http://anonscm.debian.org/gitweb/?p=d-i/debootstrap.git;a=snapshot;h=HEAD;sf=
 if ! wget -O- --no-verbose --timeout=60 -t2 "$d"  \
         | tar -C "$tmp" --strip-components=1 -zx 2>/dev/null; then
     echo 'Download from Debian gitweb failed. Trying latest release...' 1>&2
-    d='http://ftp.debian.org/debian/pool/main/d/debootstrap/'
+    d='http://httpredir.debian.org/debian/pool/main/d/debootstrap/'
     f="`wget -O- --no-verbose --timeout=60 -t2 "$d" \
             | sed -ne 's ^.*\(debootstrap_[0-9.]*.tar.xz\).*$ \1 p' \
             | tail -n 1`"


### PR DESCRIPTION
httpredir.debian.org chooses the best debian mirror based on your
geographic and network location.  Use it instead of ftp.debian.org.  See
http://httpredir.debian.org/ for the details.