### PR TITLE
Add Wily Werewolf to list of test releases

### DIFF
--- a/installer/ubuntu/releases
+++ b/installer/ubuntu/releases
@@ -20,3 +20,4 @@ saucy*
 trusty
 utopic*|test
 vivid*|test
+wily*|test


### PR DESCRIPTION
It took until very late in development cycle for Utopic and/or Vivid to be added, so I'm proposing this pull request to change that.