### PR TITLE
freon, xorg: Modify Intel driver to fix black screen on switch/exit (stretch/utopic)

### DIFF
--- a/src/freon.c
+++ b/src/freon.c
@@ -209,3 +209,8 @@ int close(int fd) {
     }
     return orig_close(fd);
 }
+
+uid_t getuid0(void) {
+    TRACE("getuid0\n");
+    return 0;
+}

--- a/targets/xorg
+++ b/targets/xorg
@@ -67,6 +67,9 @@ if [ "${ARCH#arm}" = "$ARCH" ]; then
             ! grep -q 0xa0 /sys/class/graphics/fb0/device/device; then
         pinmesa='y'
     fi
+
+    # Unhold xserver-xorg-video-intel, modification will be reapplied later.
+    apt-mark unhold "$inteldriver" 2>/dev/null || true
 fi
 
 # Catalog relevant and irrelevant video drivers
@@ -207,6 +210,23 @@ fi
 
 # Fix launching X11 from inside crosh (user doesn't own a TTY)
 sed -i 's/allowed_users=.*/allowed_users=anybody/' '/etc/X11/Xwrapper.config'
+
+inteldrv='/usr/lib/xorg/modules/drivers/intel_drv.so'
+if [ -n "$freon" -a -e "$inteldrv" ]; then
+    # Modify the Intel driver to call getuid0 (provided by croutonfreon.so)
+    # instead of geteuid, to force DRM master setting/dropping.
+    offset="`grep -F -m 1 -boa 'geteuid' "$inteldrv" 2>/dev/null || true`"
+    if [ -n "$offset" ]; then
+        echo -n 'getuid0' | dd seek="${offset%:*}" bs=1 of="$inteldrv" \
+                               conv=notrunc,nocreat 2>/dev/null
+    fi
+
+    if grep -F -q -a 'getuid0' "$inteldrv" 2>/dev/null; then
+        # Hold xserver-xorg-video-intel to make sure that the modification
+        # (which may have been made in a previous update) does not get erased.
+        apt-mark hold "$inteldriver"
+    fi
+fi
 
 TIPS="$TIPS
 You can flip through your running chroot desktops and Chromium OS by hitting


### PR DESCRIPTION
- freon: Add getuid0, to be used in place of geteuid but always returns 0.
- xorg: Modify Intel driver (xserver-xorg-video-intel) to call getuid0 instead of geteuid, to force DRM master setting/dropping.

xserver-xorg-video-intel commit [e0c93a3e53a624beb5d3a15631237ac33b8c92cd](https://anonscm.debian.org/cgit/pkg-xorg/driver/xserver-xorg-video-intel.git/commit/?id=e0c93a3e53a624beb5d3a15631237ac33b8c92cd) introduces a change where the driver does not set or drop DRM master if running as a non-root user.  Since the Intel driver no longer drops DRM master, Chromium OS is unable to reacquire it on switch or Xorg exit, resulting in a black screen.

The Intel driver modification effectively reverts to the earlier behavior of explicitly setting and dropping DRM master, even when Xorg runs as non-root user.

---

This addresses the problem introduced in Debian stretch/Ubuntu utopic whereby Intel devices go to into an (effectively) unreconverable black screen after exiting Xorg, or switching back from Xorg to Chrome OS.

Originally I tried to implement a solution solely in croutonfreon.so, avoiding modification of intel_drv.so, by having freon drop DRM master during tty7 deactivation.  [Here's the WIP](https://github.com/mkasick/crouton/tree/freon-drm) attempt to do that, which _does_ work on the initial switch/exit from Xorg to Chrome OS, but fails to show Xorg when trying to switch back as the driver does not explicitly set DRM master either (the first acquisition must be implicit).  Unfortunately there's no easy way to have freon set DRM master since it's unclear which DRI card fd is responsible for calling it; and also because it [has to be called in a loop](https://anonscm.debian.org/cgit/pkg-xorg/driver/xserver-xorg-video-intel.git/tree/src/intel_device.c#n731) as, when switching between two Xorg sessions, the switched-from session does not release master right away.

The alternative approach, used here, is to have freon return 0 for the driver's geteuid call so that the driver deals with DRM master itself.  I didn't want to simply intercept all geteuid calls from the X server as it's made frequently by other components and I'm uncertain of the consequence of faking privilege  for all of them.  However, by modifying the driver's dynamic symbol for geteuid to reference a unique function (getuid0), we can intercept (really, just implement) that one call.

There's a second instance where the Intel driver calls geteuid in sna_accel_leave/sna_leave_vt that would also be altered here.  However I only see one call to getuid0 in the freon TRACE logs, and I've yet to see any other ill effects.

Unrelated, but I noticed that the xserver-xorg-core package isn't put on hold after applying the vgem hack in the x11-common target, should it be?