### PR TITLE
stateful_partition symlink for fresh installs

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -389,7 +389,7 @@ if [ -z "$RESTOREBIN$DOWNLOADONLY" ]; then
     # to catch situations where things are bind-mounted over /usr/local
     truechroots="/mnt/stateful_partition/dev_image/chroots"
     if [ -z "$PREFIXSET" -a ! -h "$CHROOTS" ] \
-            && [ "$CHROOTS" -ef "$truechroots" ]; then
+            && ([ ! -e "$CHROOTS" ] || [ "$CHROOTS" -ef "$truechroots" ]); then
         # Detect if chroots are left in the old chroots directory, and move them
         # to the new directory.
         if [ -e "$CHROOTS" ] && ! rmdir "$CHROOTS" 2>/dev/null; then


### PR DESCRIPTION
* If /usr/local/chroots does not exist, make a symlink from
  /mnt/stateful_partition/crouton/chroots
* Fixes #1397