### PR TITLE
30-audio: Feed actual data to pacat

### DIFF
--- a/test/tests/30-audio
+++ b/test/tests/30-audio
@@ -49,7 +49,7 @@ echo 'install pulseaudio pulseaudio-utils' | \
     crouton -T -U -n "$release"
 exitswithin 0 30 host enter-chroot -n "$release" sh -exc '
     pulseaudio --start
-    echo | pacat -v
+    dd if=/dev/zero bs=48000 count=8 | pacat -v
     dd if=/dev/zero bs=48000 count=8 | aplay -f dat -Dpulse -v
     arecord -fdat -Dpulse -v | \
         dd if=/dev/null bs=48000 count=8 iflag=fullblock


### PR DESCRIPTION
For some reason `pacat -v` does not like being fed just one char and fails on recent pulseaudio.

Test run here: 2015-08-27_08-58-59_drinkcat_chroagh_fix-audio-pacat_30.

Fixes #2011.