### PR TITLE
Change the condition of applying vgem hack

### DIFF
--- a/targets/x11-common
+++ b/targets/x11-common
@@ -12,7 +12,7 @@ ln -sfT '/etc/crouton/xserverrc' '/etc/X11/xinit/xserverrc'
 echo "$XMETHOD" > '/etc/crouton/xmethod'
 
 # Only apply hack if vgem card exists
-if [ -c '/dev/dri/card1' -o -d '/sys/class/drm/card1/' ]; then
+if [ -d '/sys/class/drm/card1/' ]; then
     # Modify the Xorg executable to *not* poll udev for cards
     offset="`grep -F -m 1 -boa 'card[0-9]*' /usr/bin/Xorg 2>/dev/null || true`"
     if [ -n "$offset" ]; then

--- a/targets/x11-common
+++ b/targets/x11-common
@@ -12,7 +12,7 @@ ln -sfT '/etc/crouton/xserverrc' '/etc/X11/xinit/xserverrc'
 echo "$XMETHOD" > '/etc/crouton/xmethod'
 
 # Only apply hack if vgem card exists
-if [ -c '/dev/dri/card1' ]; then
+if [ -c '/dev/dri/card1' -o -d '/sys/class/drm/card1/' ]; then
     # Modify the Xorg executable to *not* poll udev for cards
     offset="`grep -F -m 1 -boa 'card[0-9]*' /usr/bin/Xorg 2>/dev/null || true`"
     if [ -n "$offset" ]; then


### PR DESCRIPTION
It seems that xserver will also check /sys/class/drm/card1/ for vgem existence,
so also apply the hack when the directory exists.