### PR TITLE
Deny auto start services.

### DIFF
--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -230,6 +230,11 @@ if [ -r /debootstrap ]; then
     /debootstrap/debootstrap --second-stage
     # Clean contents of /var/run (since we'll always be mounting over it).
     rm -rf --one-file-system /var/run/*
+    # dpkg will auto start some services when installing, and it will ask
+    # policy-rc.d for permissions. We don't want any service to start, so always
+    # return denies.
+    echo exit 101 > /usr/sbin/policy-rc.d
+    chmod +x /usr/sbin/policy-rc.d
     # Request a script restart to refresh the mount environment
     relaunch_setup
 else

--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -217,6 +217,12 @@ install_mirror_package() {
 # Run dpkg in non-interactive mode
 export DEBIAN_FRONTEND=noninteractive
 
+# dpkg will auto start some services when installing, and it will ask
+# policy-rc.d for permissions. We don't want any service to start, so always
+# return denies.
+echo exit 101 > /usr/sbin/policy-rc.d
+chmod +x /usr/sbin/policy-rc.d
+
 # Run debootstrap second stage if it hasn't already happened
 if [ -r /debootstrap ]; then
     # Debootstrap doesn't like anything mounted under /sys or /var when it runs
@@ -230,11 +236,6 @@ if [ -r /debootstrap ]; then
     /debootstrap/debootstrap --second-stage
     # Clean contents of /var/run (since we'll always be mounting over it).
     rm -rf --one-file-system /var/run/*
-    # dpkg will auto start some services when installing, and it will ask
-    # policy-rc.d for permissions. We don't want any service to start, so always
-    # return denies.
-    echo exit 101 > /usr/sbin/policy-rc.d
-    chmod +x /usr/sbin/policy-rc.d
     # Request a script restart to refresh the mount environment
     relaunch_setup
 else


### PR DESCRIPTION
dpkg may start some services when installing, and we deny all of
them by return 101 in /usr/sbin/policy-rc.d. Users can still start
services manually by `start some-service` if they need it.