### PR TITLE
Improve freon interaction

### DIFF
--- a/chroot-etc/xserverrc-xorg
+++ b/chroot-etc/xserverrc-xorg
@@ -25,11 +25,6 @@ if [ ! -f "/sys/class/tty/tty0/active" ]; then
             exit 2
         fi
     done
-    # Use the daemon to kill frecon.
-    # FIXME: remove when crbug.com/457075 is resolved
-    if [ -w '/tmp/crouton-lock/frecon' ]; then
-        echo >> '/tmp/crouton-lock/frecon'
-    fi
     # Freon necessitates the preload hack for X to coexist
     X=/usr/bin/Xorg
     logfile="/tmp/Xorg.crouton.$$.log"

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -659,27 +659,6 @@ if [ ! "$NOLOGIN" = 1 ] && grep -q '^root:' "$passwd" 2>/dev/null; then
         # systemd-logind doesn't fork
         chrootcmd "/lib/systemd/systemd-logind >/dev/null 2>&1 </dev/null &"
     fi
-
-    # Launch a daemon that can kill frecon when an X server is launched.
-    # FIXME: remove when crbug.com/457075 is resolved
-    if [ -f /sbin/frecon ]; then
-        mkdir -p "$CROUTONLOCKDIR"
-        chmod 777 "$CROUTONLOCKDIR"
-        if [ ! -e "$CROUTONLOCKDIR/frecon" ]; then
-            mkfifo "$CROUTONLOCKDIR/frecon"
-            chmod 622 "$CROUTONLOCKDIR/frecon"
-        fi
-        chrootcmd "(exec >/dev/null 2>&1 </dev/null
-            while read -r cmd <'$CROUTONLOCKDIR/frecon'; do
-                if [ \"\$cmd\" = $$ ]; then
-                    break
-                elif [ -z \"\$cmd\" ]; then
-                    pkill '^frecon\$' || true
-                fi
-            done
-        ) &"
-        addtrap "(echo $$ >> '$CROUTONLOCKDIR/frecon') & :"
-    fi
 fi
 
 # Start the chroot and any specified command

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -530,6 +530,19 @@ if ! mountpoint -q "$CHROOT/sys"; then
     mount --make-rslave "$CHROOT/sys"
 fi
 
+# Modify chroot's /sys/class/drm to avoid vgem
+varrundrm="$(fixabslinks '/var/run/drm')"
+sysclassdrm="$(fixabslinks '/sys/class/drm')"
+if [ ! -d "$varrundrm" -a -d "$sysclassdrm" ]; then
+    cp -Ta "$sysclassdrm" "$varrundrm"
+    for f in "$varrundrm"/*; do
+        if [ -h "$f" ] && readlink "$f" | grep -qF /vgem/; then
+            rm -f "$f"
+        fi
+    done
+    mount --bind "$varrundrm" "$sysclassdrm"
+fi
+
 # Get croutonversion variables
 croutonversion="$CHROOT/usr/local/bin/croutonversion"
 CHROOTRELEASE="unknown"

--- a/targets/x11-common
+++ b/targets/x11-common
@@ -11,21 +11,11 @@
 ln -sfT '/etc/crouton/xserverrc' '/etc/X11/xinit/xserverrc'
 echo "$XMETHOD" > '/etc/crouton/xmethod'
 
-# Only apply hack if vgem card exists
-if [ -c '/dev/dri/card1' ]; then
-    # Modify the Xorg executable to *not* poll udev for cards
-    offset="`grep -F -m 1 -boa 'card[0-9]*' /usr/bin/Xorg 2>/dev/null || true`"
-    if [ -n "$offset" ]; then
-        echo -n 'croutonhax' | dd seek="${offset%:*}" bs=1 of=/usr/bin/Xorg \
-            conv=notrunc,nocreat 2>/dev/null
-    fi
-elif grep -q 'croutonhax' '/usr/bin/Xorg'; then
-    # Undo hack since there's no vgem module
-    offset="`grep -F -m 1 -boa 'croutonhax' /usr/bin/Xorg 2>/dev/null || true`"
-    if [ -n "$offset" ]; then
-        echo -n 'card[0-9]*' | dd seek="${offset%:*}" bs=1 of=/usr/bin/Xorg \
-            conv=notrunc,nocreat 2>/dev/null
-    fi
+# Remove old vgem hack
+offset="`grep -F -m 1 -boa 'croutonhax' /usr/bin/Xorg 2>/dev/null || true`"
+if [ -n "$offset" ]; then
+    echo -n 'card[0-9]*' | dd seek="${offset%:*}" bs=1 of=/usr/bin/Xorg \
+        conv=notrunc,nocreat 2>/dev/null
 fi
 
 # Install utility for croutoncycle


### PR DESCRIPTION
Get rid of the xorg binary hack and instead adjust /sys/class/drm inside the chroot.  Fixes #1938 

Don't kill frecon anymore; fixes #2095