### PR TITLE
download debootstrap using HTTPS

### DIFF
--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -10,7 +10,7 @@
 
 # Grab the latest release of debootstrap
 echo 'Downloading latest debootstrap...' 1>&2
-d='http://anonscm.debian.org/gitweb/?p=d-i/debootstrap.git;a=snapshot;h=HEAD;sf=tgz'
+d='https://anonscm.debian.org/gitweb/?p=d-i/debootstrap.git;a=snapshot;h=HEAD;sf=tgz'
 if ! wget -O- --no-verbose --timeout=60 -t2 "$d"  \
         | tar -C "$tmp" --strip-components=1 -zx 2>/dev/null; then
     echo 'Download from Debian gitweb failed. Trying latest release...' 1>&2


### PR DESCRIPTION
RE: security issue with a dead simple fix: download debootstrap using HTTPS #2067 - originally by eighthave

Right now, crouton downloads debootstrap from anonscm.debian.org using an HTTP link. That URL is also accessible using an HTTPS link, e.g.