### PR TITLE
Support enter-chroot in a chroot (nested enter-chroot)

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -155,6 +155,14 @@ fi
 # Make sure we always exit with echo on the tty.
 addtrap "stty echo 2>/dev/null"
 
+# Determine whether we're running in a chroot already (i.e. nested enter-chroot)
+if [ ! -d "/var/run/shill" ]; then
+    echo "Already in a chroot..."
+    NESTED_ENTER_CHROOT=1
+else
+    NESTED_ENTER_CHROOT=0
+fi
+
 # Mount the chroot and update our CHROOT path
 CHROOTSRC="$CHROOTS/$NAME"
 if [ -n "$KEYFILE" ]; then
@@ -263,13 +271,21 @@ echo "$NAME" > "$CHROOT/etc/crouton/name"
 mkdir -p "$CHROOT/var/host"
 
 # Copy in the current Chromium OS version for reference
-cp -f '/etc/lsb-release' "$CHROOT/var/host/"
+host_path="/etc"
+if [ $NESTED_ENTER_CHROOT ]; then
+    host_path="/var/host"
+fi
+cp -f "${host_path}/lsb-release" "$CHROOT/var/host/"
 
 # Copy CRAS version into the chroot
 cras_test_client --version 2>/dev/null > "$CHROOT/var/host/cras-version" || true
 
 # Copy the latest Xauthority into the chroot
-if [ -f "${XAUTHORITY:=/home/chronos/.Xauthority}" ]; then
+host_path="/home/chronos/.Xauthority"
+if [ $NESTED_ENTER_CHROOT ]; then
+    host_path="/var/host/Xauthority"
+fi
+if [ -f "${XAUTHORITY:=$host_path}" ]; then
     cp -f "$XAUTHORITY" "$CHROOT/var/host/Xauthority"
     chmod 444 "$CHROOT/var/host/Xauthority"
     # Be backwards-compatible, just in case
@@ -353,8 +369,16 @@ bindmount /proc
 tmpfsmount /var/run 'noexec,nosuid,mode=0755,size=10%'
 tmpfsmount /var/run/lock 'noexec,nosuid,nodev,size=5120k'
 bindmount /var/run/dbus /var/host/dbus
-bindmount /var/run/shill /var/host/shill
-bindmount /var/lib/timezone /var/host/timezone
+host_path="/var/run"
+if [ $NESTED_ENTER_CHROOT ]; then
+    host_path="/var/host"
+fi
+bindmount "${host_path}/shill" /var/host/shill
+host_path="/var/lib"
+if [ $NESTED_ENTER_CHROOT ]; then
+    host_path="/var/host"
+fi
+bindmount "${host_path}/timezone" /var/host/timezone
 for m in /lib/modules/*; do
     if [ -d "$m" ]; then
         bindmount '-o ro' "$m"
@@ -386,7 +410,9 @@ fi
 # Bind-mount /media, specifically the removable directory
 destmedia="`fixabslinks '/var/host/media'`"
 if ! mountpoint -q "$destmedia"; then
-    mount --make-shared /media
+    # Might indeed fail if NESTED_ENTER_CHROOT as /media might not be in /etc/{fs,m}tab
+    mount --make-shared /media || $(exit $((! $NESTED_ENTER_CHROOT)))
+
     mkdir -p "$destmedia" "$CHROOT/media"
     ln -sf "/var/host/media/removable" "$CHROOT/media/"
     mount --rbind /media "$destmedia"

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -272,7 +272,7 @@ mkdir -p "$CHROOT/var/host"
 
 # Copy in the current Chromium OS version for reference
 host_path="/etc"
-if [ $NESTED_ENTER_CHROOT ]; then
+if [ $NESTED_ENTER_CHROOT = 1 ]; then
     host_path="/var/host"
 fi
 cp -f "${host_path}/lsb-release" "$CHROOT/var/host/"
@@ -282,7 +282,7 @@ cras_test_client --version 2>/dev/null > "$CHROOT/var/host/cras-version" || true
 
 # Copy the latest Xauthority into the chroot
 host_path="/home/chronos/.Xauthority"
-if [ $NESTED_ENTER_CHROOT ]; then
+if [ $NESTED_ENTER_CHROOT = 1 ]; then
     host_path="/var/host/Xauthority"
 fi
 if [ -f "${XAUTHORITY:=$host_path}" ]; then
@@ -370,12 +370,12 @@ tmpfsmount /var/run 'noexec,nosuid,mode=0755,size=10%'
 tmpfsmount /var/run/lock 'noexec,nosuid,nodev,size=5120k'
 bindmount /var/run/dbus /var/host/dbus
 host_path="/var/run"
-if [ $NESTED_ENTER_CHROOT ]; then
+if [ $NESTED_ENTER_CHROOT = 1 ]; then
     host_path="/var/host"
 fi
 bindmount "${host_path}/shill" /var/host/shill
 host_path="/var/lib"
-if [ $NESTED_ENTER_CHROOT ]; then
+if [ $NESTED_ENTER_CHROOT = 1 ]; then
     host_path="/var/host"
 fi
 bindmount "${host_path}/timezone" /var/host/timezone


### PR DESCRIPTION
This PR implements a support for entering a crouton chroot from another chroot. 

Use case: I have two full self-contained chroots able to run their own X and desktop environments, but **sometimes** I just want to "start" `myGreatChroot1` and from there quickly enter `myGreatChroot2` and run a command using `myGreatChroot1`'s X server (i.e. without starting `myGreatChroot2`'s X server).

Here is how it now works, based on this PR.

Install this version of `enter-chroot` on the host (temporary hack until this PR gets merged):

```
localhost# cd installer
localhost# export INSTALLERDIR=`pwd`
localhost# . functions
localhost# cd ..
localhost# installscript host-bin/enter-chroot /usr/local/bin/
localhost# chmod 755 /usr/local/bin/enter-chroot
```

Create two chroots:

```
chronos@localhost$ sudo sh crouton -t xfce -n myGreatChroot1
chronos@localhost$ sudo sh crouton -t xfce -n myGreatChroot2
```

"Start" the first chroot:

```
chronos@localhost$ sudo startxfce4 -n myGreatChroot1
```

Install crouton in the first chroot:

```
(myGreatChroot1)user@localhost$ sudo apt-get install curl
(myGreatChroot1)user@localhost$ sudo sh crouton -b
(myGreatChroot1)user@localhost$ sudo mkdir /mnt/stateful_partition
(myGreatChroot1)user@localhost$ sudo mount /dev/mmcblk0p1 /mnt/stateful_partition
(myGreatChroot1)user@localhost$ sudo ln -s /mnt/stateful_partition/crouton/chroots /usr/local/chroots
(myGreatChroot1)user@localhost$ sudo ln -s /usr/sbin/chroot /usr/bin/chroot
```

Install this version of `enter-chroot` in the first chroot (temporary hack until this PR gets merged):

```
(myGreatChroot1)root@localhost# cd installer
(myGreatChroot1)root@localhost# export INSTALLERDIR=`pwd`
(myGreatChroot1)root@localhost# . functions
(myGreatChroot1)root@localhost# cd ..
(myGreatChroot1)root@localhost# installscript host-bin/enter-chroot /usr/local/bin/
(myGreatChroot1)root@localhost# chmod 755 /usr/local/bin/enter-chroot
```

From the first chroot, enter the second one:

```
(myGreatChroot1)user@localhost$ sudo enter-chroot -n myGreatChroot2
(myGreatChroot2)user@localhost$ export DISPLAY=:1
(myGreatChroot2)user@localhost$ xmessage here you go!
```

I have run the test `10-basic.precise` locally using my modified `enter-chroot`: no regression. I have also played around myself to make sure entering chroots the usual way still works.

I have signed the CLA.

Let me know if you need me to improve anything before merging the PR. Thanks!
