### PR TITLE
Add copy option -u to edit-chroot

### DIFF
--- a/host-bin/edit-chroot
+++ b/host-bin/edit-chroot
@@ -58,12 +58,7 @@ Options:
                 If multiple chroots are specified, DEST must be a directory.
                 If you are moving a chroot to a SD card/USB drive, make sure the
                 storage is formatted to ext2/3/4.
-    -u DEST     Copies a chroot. Specify a new name to keep it in the same
-                directory, or an absolute path.
-                DEST can be a directory, in which case it must end in a slash.
-                If multiple chroots are specified, DEST must be a directory.
-                If you are copying a chroot to a SD card/USB drive, make sure the
-                storage is formatted to ext2/3/4.
+    -u DEST     Like -m, but copies instead of moves.
     -r          Restores a chroot from a tarball. The tarball path can be
                 specified with -f or detected from name. If both are specified,
                 restores to that name instead of the one in the tarball.
@@ -172,7 +167,7 @@ if [ $# -gt 1 -a -f "$KEYFILE" -a ! "$KEYFILE" = '-' ]; then
 elif [ $# -gt 1 -a -n "$MOVE" -a "${MOVE%/}" = "$MOVE" ]; then
     error 2 "Multiple chroots specified, but $MOVE is not a directory."
 elif [ $# -gt 1 -a -n "$COPY" -a "${COPY%/}" = "$COPY" ]; then
-      error 2 "Multiple chroots specified, but $COPY is not a directory."
+    error 2 "Multiple chroots specified, but $COPY is not a directory."
 elif [ $# -gt 1 -a -f "$TARBALL" ]; then
     error 2 "Multiple chroots specified, but $TARBALL is not a directory."
 fi
@@ -638,7 +633,7 @@ for NAME in "$@"; do
             error 1 "Unable to create directory for $target"
         fi
         echo "Copying $CHROOT to $target" 1>&2
-        cp -a "$CHROOT" "$target"
+        spinner 200 cp -av --one-file-system "$CHROOT" "$target"
     fi
 done
 

--- a/host-bin/edit-chroot
+++ b/host-bin/edit-chroot
@@ -58,7 +58,7 @@ Options:
                 If multiple chroots are specified, DEST must be a directory.
                 If you are moving a chroot to a SD card/USB drive, make sure the
                 storage is formatted to ext2/3/4.
-    -u DEST     Like -m, but copies instead of moves.
+    -C DEST     Like -m, but copies instead of moves.
     -r          Restores a chroot from a tarball. The tarball path can be
                 specified with -f or detected from name. If both are specified,
                 restores to that name instead of the one in the tarball.
@@ -74,12 +74,13 @@ Options:
 . "$BINDIR/../installer/functions"
 
 # Process arguments
-getopts_string='abc:def:k:lm:rs:u:y'
+getopts_string='abc:C:def:k:lm:rs:y'
 while getopts_nextarg; do
     case "$getopts_var" in
     a) ALLCHROOTS='y';;
     b) BACKUP='y'; NEEDS_UNMOUNT='y';;
     c) CHROOTS="`readlink -m -- "$getopts_arg"`";;
+    C) COPY="$getopts_arg"; NEEDS_UNMOUNT='y';;
     d) DELETE='y'; NEEDS_UNMOUNT='y';;
     e) ENCRYPT='y'; NEEDS_UNMOUNT='y';;
     f) TARBALL="$getopts_arg";;
@@ -88,7 +89,6 @@ while getopts_nextarg; do
     m) MOVE="$getopts_arg"; NEEDS_UNMOUNT='y';;
     r) RESTORE=$(($RESTORE+1)); NEEDS_UNMOUNT='y';;
     s) SPLIT="$getopts_arg";;
-    u) COPY="$getopts_arg"; NEEDS_UNMOUNT='y';;
     y) YES='a'; YESPARAM='-y';;
     \?) error 2 "$USAGE";;
     esac

--- a/host-bin/edit-chroot
+++ b/host-bin/edit-chroot
@@ -15,6 +15,7 @@ ENCRYPT=''
 KEYFILE=''
 LISTDETAILS=''
 MOVE=''
+COPY=''
 NEEDS_UNMOUNT=''
 RESTORE=''
 SPLIT=''
@@ -57,6 +58,12 @@ Options:
                 If multiple chroots are specified, DEST must be a directory.
                 If you are moving a chroot to a SD card/USB drive, make sure the
                 storage is formatted to ext2/3/4.
+    -u DEST     Copies a chroot. Specify a new name to keep it in the same
+                directory, or an absolute path.
+                DEST can be a directory, in which case it must end in a slash.
+                If multiple chroots are specified, DEST must be a directory.
+                If you are copying a chroot to a SD card/USB drive, make sure the
+                storage is formatted to ext2/3/4.
     -r          Restores a chroot from a tarball. The tarball path can be
                 specified with -f or detected from name. If both are specified,
                 restores to that name instead of the one in the tarball.
@@ -72,7 +79,7 @@ Options:
 . "$BINDIR/../installer/functions"
 
 # Process arguments
-getopts_string='abc:def:k:lm:rs:y'
+getopts_string='abc:def:k:lm:rs:u:y'
 while getopts_nextarg; do
     case "$getopts_var" in
     a) ALLCHROOTS='y';;
@@ -86,6 +93,7 @@ while getopts_nextarg; do
     m) MOVE="$getopts_arg"; NEEDS_UNMOUNT='y';;
     r) RESTORE=$(($RESTORE+1)); NEEDS_UNMOUNT='y';;
     s) SPLIT="$getopts_arg";;
+    u) COPY="$getopts_arg"; NEEDS_UNMOUNT='y';;
     y) YES='a'; YESPARAM='-y';;
     \?) error 2 "$USAGE";;
     esac
@@ -98,7 +106,7 @@ if [ ! "${APPLICATION#delete}" = "$APPLICATION" ]; then
 fi
 
 # At least one command must be specified
-if [ -z "$ALLCHROOTS$BACKUP$DELETE$ENCRYPT$KEYFILE$LISTDETAILS$MOVE$RESTORE" ]; then
+if [ -z "$ALLCHROOTS$BACKUP$DELETE$ENCRYPT$KEYFILE$LISTDETAILS$MOVE$COPY$RESTORE" ]; then
     error 2 "$USAGE"
 fi
 
@@ -122,8 +130,13 @@ if [ -n "$BACKUP" -a -n "$RESTORE" ]; then
     error 2 "$USAGE"
 fi
 
+# Cannot specify both copy and move.
+if [ -n "$COPY" -a -n "$MOVE" ]; then
+    error 2 "$USAGE"
+fi
+
 # Cannot specify delete with anything else.
-if [ -n "$DELETE" -a -n "$BACKUP$ENCRYPT$KEYFILE$MOVE$RESTORE" ]; then
+if [ -n "$DELETE" -a -n "$BACKUP$ENCRYPT$KEYFILE$MOVE$COPY$RESTORE" ]; then
     error 2 "$USAGE"
 fi
 
@@ -153,11 +166,13 @@ if [ -n "$BACKUP$RESTORE" -a -z "$TARBALL" -a "$PWD" = '/' \
     TARBALL="/home/chronos/user/Downloads/"
 fi
 
-# If multiple chroots are listed, KEYFILE and MOVE must be empty or directories.
+# If multiple chroots are listed, KEYFILE and MOVE and COPY must be empty or directories.
 if [ $# -gt 1 -a -f "$KEYFILE" -a ! "$KEYFILE" = '-' ]; then
     error 2 "Multiple chroots specified, but $KEYFILE is not a directory."
 elif [ $# -gt 1 -a -n "$MOVE" -a "${MOVE%/}" = "$MOVE" ]; then
     error 2 "Multiple chroots specified, but $MOVE is not a directory."
+elif [ $# -gt 1 -a -n "$COPY" -a "${COPY%/}" = "$COPY" ]; then
+      error 2 "Multiple chroots specified, but $COPY is not a directory."
 elif [ $# -gt 1 -a -f "$TARBALL" ]; then
     error 2 "Multiple chroots specified, but $TARBALL is not a directory."
 fi
@@ -166,6 +181,12 @@ fi
 if [ -n "$MOVE" -a "${MOVE#*/}" != "$MOVE" ] && \
         df -T "`getmountpoint "$MOVE"`" | awk '$2~"^ext"{exit 1}'; then
     error 2 "Chroots can only be moved to ext filesystems."
+fi
+
+# Don't allow copying to non-ext filesystems (but don't check if in same directory)
+if [ -n "$COPY" -a "${COPY#*/}" != "$COPY" ] && \
+        df -T "`getmountpoint "$COPY"`" | awk '$2~"^ext"{exit 1}'; then
+    error 2 "Chroots can only be copied to ext filesystems."
 fi
 
 # Don't allow restoring to non-ext filesystems
@@ -240,7 +261,7 @@ Please specify all options before chroot names."
 done
 
 # Display all chroot names if using -a without any other operations.
-if [ -n "$ALLCHROOTS" -a -z "$BACKUP$DELETE$ENCRYPT$KEYFILE$LISTDETAILS$MOVE$RESTORE" ]; then
+if [ -n "$ALLCHROOTS" -a -z "$BACKUP$DELETE$ENCRYPT$KEYFILE$LISTDETAILS$MOVE$COPY$RESTORE" ]; then
     echo "$@"
     exit 0
 fi
@@ -593,6 +614,31 @@ for NAME in "$@"; do
             echo "Moving $CHROOT to $target" 1>&2
             mv "$CHROOT" "$target"
         fi
+    fi
+
+    # Copy the chroot if requested
+    if [ -n "$COPY" ]; then
+        target="$COPY"
+        if [ "${target##*/}" = "$target" ]; then
+            # No slashes in the path. Assume same directory.
+            if ! validate_name "$target"; then
+                error 2 "Invalid target chroot name '$target'."
+            fi
+            target="$CHROOTS/$target"
+        elif [ ! "${target%/}" = "$target" ]; then
+            # Ends in a slash; append name.
+            target="$target$NAME"
+        fi
+        if [ -e "$target" ]; then
+            # Can't tell if the destination is a directory or a chroot that
+            # already exists; be safe and assume it was a mistake.
+            error 2 "$target already exists"
+        fi
+        if ! mkdir -p "`dirname "$target"`"; then
+            error 1 "Unable to create directory for $target"
+        fi
+        echo "Copying $CHROOT to $target" 1>&2
+        cp -a "$CHROOT" "$target"
     fi
 done
 

--- a/test/tests/12-edit-chroot
+++ b/test/tests/12-edit-chroot
@@ -78,8 +78,10 @@ host enter-chroot -n "$release.2" true
 fails host enter-chroot -n "$release" true
 
 # Cannot copy a chroot that does not exist
-host edit-chroot -y "$release" -C "$release.3"
-fails host enter-chroot -n "$release.3" true
+fails host edit-chroot -y "$release" -C "$release.3"
+
+# Cannot copy and move a chroot
+fails host edit-chroot -y "$release" -C "$release.3" -m "$release.4"
 
 # Copy a chroot
 host edit-chroot -y "$release.2" -C "$release.3"

--- a/test/tests/12-edit-chroot
+++ b/test/tests/12-edit-chroot
@@ -77,6 +77,18 @@ host edit-chroot -y "$release" -m "$release.2"
 host enter-chroot -n "$release.2" true
 fails host enter-chroot -n "$release" true
 
+# Cannot copy a chroot that does not exist
+host edit-chroot -y "$release" -u "$release.3"
+fails host enter-chroot -n "$release.3" true
+
+# Copy a chroot
+host edit-chroot -y "$release.2" -u "$release.3"
+host enter-chroot -n "$release.3" true
+
+# Delete the copy
+host delete-chroot -y "$release.3"
+fails host enter-chroot -n "$release.3" true
+
 # Restore the chroot
 host edit-chroot -y -f "$BACKUPDIR/$release.tar" -r "$release"
 host enter-chroot -n "$release" true
@@ -154,6 +166,23 @@ host delete-chroot "$release" "$release.2" -y -c "$PREFIX/chroots.2"
 fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
 fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
 
+# Copy them to a new prefix: destination needs to end with a slash
+fails host edit-chroot -y -u "$PREFIX/chroots.2" "$release" "$release.2"
+host enter-chroot -n "$release" true
+host enter-chroot -n "$release.2" true
+
+host edit-chroot -y -u "$PREFIX/chroots.2/" "$release" "$release.2"
+host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
+host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
+
+# Delete all four chroots
+host delete-chroot "$release" "$release.2" -y -c "$PREFIX/chroots.2"
+host delete-chroot "$release" "$release.2" -y
+fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
+fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
+fails host enter-chroot -n "$release" true
+fails host enter-chroot -n "$release.2" true
+
 OLDCWD="`pwd`"
 
 # Restore both chroots from automatically named tarballs in current directory
@@ -180,6 +209,13 @@ fails ls "$BACKUPDIR"/*
 fails host edit-chroot -y -m "." -- "-$release"
 fails host edit-chroot -y -m ".." -- "-$release"
 fails host edit-chroot -y -m "" -- "-$release"
+host enter-chroot -n "-$release" true
+
+# Check invalid names are also detected in parameter to -u
+# (/ are acceptable in this context, as target directory)
+fails host edit-chroot -y -u "." -- "-$release"
+fails host edit-chroot -y -u ".." -- "-$release"
+fails host edit-chroot -y -u "" -- "-$release"
 host enter-chroot -n "-$release" true
 
 # Delete both chroots

--- a/test/tests/12-edit-chroot
+++ b/test/tests/12-edit-chroot
@@ -85,6 +85,7 @@ fails host edit-chroot -y "$release" -C "$release.3" -m "$release.4"
 
 # Copy a chroot
 host edit-chroot -y "$release.2" -C "$release.3"
+host enter-chroot -n "$release.2" true
 host enter-chroot -n "$release.3" true
 
 # Delete the copy
@@ -154,36 +155,33 @@ fails ls "$BACKUPDIR"/*
 # Backup both chroots
 host edit-chroot "$release" -y -f "$BACKUPDIR" -b "$release.2"
 
-# Move them to a new prefix: destination needs to end with a slash
-fails host edit-chroot -y -m "$PREFIX/chroots.2" "$release" "$release.2"
-host enter-chroot -n "$release" true
-host enter-chroot -n "$release.2" true
-
-host edit-chroot -y -m "$PREFIX/chroots.2/" "$release" "$release.2"
-host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
-host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
-
-# Delete both chroots
-host delete-chroot "$release" "$release.2" -y -c "$PREFIX/chroots.2"
-fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
-fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
-
 # Copy them to a new prefix: destination needs to end with a slash
 fails host edit-chroot -y -C "$PREFIX/chroots.2" "$release" "$release.2"
-host enter-chroot -n "$release" true
-host enter-chroot -n "$release.2" true
 
 host edit-chroot -y -C "$PREFIX/chroots.2/" "$release" "$release.2"
 host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
 host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
+host enter-chroot -n "$release" true
+host enter-chroot -n "$release.2" true
+
+# Move them to a new prefix: destination needs to end with a slash
+fails host edit-chroot -y -m "$PREFIX/chroots.3" "$release" "$release.2"
+host enter-chroot -n "$release" true
+host enter-chroot -n "$release.2" true
+
+host edit-chroot -y -m "$PREFIX/chroots.3/" "$release" "$release.2"
+host enter-chroot -c "$PREFIX/chroots.3" -n "$release" true
+host enter-chroot -c "$PREFIX/chroots.3" -n "$release.2" true
+fails host enter-chroot -n "$release" true
+fails host enter-chroot -n "$release.2" true
 
 # Delete all four chroots
 host delete-chroot "$release" "$release.2" -y -c "$PREFIX/chroots.2"
-host delete-chroot "$release" "$release.2" -y
+host delete-chroot "$release" "$release.2" -y -c "$PREFIX/chroots.3"
 fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
 fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
-fails host enter-chroot -n "$release" true
-fails host enter-chroot -n "$release.2" true
+fails host enter-chroot -c "$PREFIX/chroots.3" -n "$release" true
+fails host enter-chroot -c "$PREFIX/chroots.3" -n "$release.2" true
 
 OLDCWD="`pwd`"
 

--- a/test/tests/12-edit-chroot
+++ b/test/tests/12-edit-chroot
@@ -78,11 +78,11 @@ host enter-chroot -n "$release.2" true
 fails host enter-chroot -n "$release" true
 
 # Cannot copy a chroot that does not exist
-host edit-chroot -y "$release" -u "$release.3"
+host edit-chroot -y "$release" -C "$release.3"
 fails host enter-chroot -n "$release.3" true
 
 # Copy a chroot
-host edit-chroot -y "$release.2" -u "$release.3"
+host edit-chroot -y "$release.2" -C "$release.3"
 host enter-chroot -n "$release.3" true
 
 # Delete the copy
@@ -167,11 +167,11 @@ fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
 fails host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
 
 # Copy them to a new prefix: destination needs to end with a slash
-fails host edit-chroot -y -u "$PREFIX/chroots.2" "$release" "$release.2"
+fails host edit-chroot -y -C "$PREFIX/chroots.2" "$release" "$release.2"
 host enter-chroot -n "$release" true
 host enter-chroot -n "$release.2" true
 
-host edit-chroot -y -u "$PREFIX/chroots.2/" "$release" "$release.2"
+host edit-chroot -y -C "$PREFIX/chroots.2/" "$release" "$release.2"
 host enter-chroot -c "$PREFIX/chroots.2" -n "$release" true
 host enter-chroot -c "$PREFIX/chroots.2" -n "$release.2" true
 
@@ -211,11 +211,11 @@ fails host edit-chroot -y -m ".." -- "-$release"
 fails host edit-chroot -y -m "" -- "-$release"
 host enter-chroot -n "-$release" true
 
-# Check invalid names are also detected in parameter to -u
+# Check invalid names are also detected in parameter to -C
 # (/ are acceptable in this context, as target directory)
-fails host edit-chroot -y -u "." -- "-$release"
-fails host edit-chroot -y -u ".." -- "-$release"
-fails host edit-chroot -y -u "" -- "-$release"
+fails host edit-chroot -y -C "." -- "-$release"
+fails host edit-chroot -y -C ".." -- "-$release"
+fails host edit-chroot -y -C "" -- "-$release"
 host enter-chroot -n "-$release" true
 
 # Delete both chroots


### PR DESCRIPTION
Adds the option to copy a chroot using `edit-chroot -u DEST`. See #2168