### PR TITLE
Prevent checking releases in x11 target when TARGETNOINSTALL is defined.

### DIFF
--- a/targets/x11
+++ b/targets/x11
@@ -2,21 +2,23 @@
 # Copyright (c) 2015 The crouton Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-if [ -f /sbin/frecon ]; then
-    # Wheezy/Kali are too old to use KMS well
-    if release -le wheezy -le sana; then
-        REQUIRES='xiwi'
+if [ -z TARGETNOINSTALL ]; then
+    if [ -f /sbin/frecon ]; then
+        # Wheezy/Kali are too old to use KMS well
+        if release -le wheezy -le sana; then
+            REQUIRES='xiwi'
+        else
+            REQUIRES='xorg'
+        fi
+    elif grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo || \
+            ([ "${ARCH#arm}" != "$ARCH" ] && \
+            awk -F= '/_RELEASE_VERSION=/ { exit !(int($2) < 6689) }' \
+            '/etc/lsb-release'); then
+        # Xorg won't work on Samsung ARM devices or K1 on release less than 6689
+        REQUIRES='xephyr'
     else
         REQUIRES='xorg'
     fi
-elif grep -q 'SAMSUNG EXYNOS' /proc/cpuinfo || \
-        ([ "${ARCH#arm}" != "$ARCH" ] && \
-        awk -F= '/_RELEASE_VERSION=/ { exit !(int($2) < 6689) }' \
-        '/etc/lsb-release'); then
-    # Xorg won't work on Samsung ARM devices or K1 on release less than 6689
-    REQUIRES='xephyr'
-else
-    REQUIRES='xorg'
 fi
 DESCRIPTION='X11 via autodetected backend. Does not install any desktop environment.'
 . "${TARGETSDIR:="$PWD"}/common"


### PR DESCRIPTION
This should fix https://github.com/dnschneid/crouton/issues/2321