### PR TITLE
Make Xwrapper modification never fail. 

### DIFF
--- a/targets/xorg
+++ b/targets/xorg
@@ -209,7 +209,8 @@ else
 fi
 
 # Fix launching X11 from inside crosh (user doesn't own a TTY)
-sed -i 's/allowed_users=.*/allowed_users=anybody/' '/etc/X11/Xwrapper.config'
+sed -i 's/allowed_users=.*/allowed_users=anybody/' \
+    '/etc/X11/Xwrapper.config' || true
 
 inteldrv='/usr/lib/xorg/modules/drivers/intel_drv.so'
 if [ -n "$freon" -a -e "$inteldrv" ]; then


### PR DESCRIPTION
Fixes https://github.com/dnschneid/crouton/issues/2185 X-server starts just fine without the file.