### PR TITLE
Adding xenial 16.04 next lts release.

### DIFF
--- a/installer/ubuntu/releases
+++ b/installer/ubuntu/releases
@@ -21,3 +21,4 @@ trusty
 utopic*
 vivid*|test
 wily*|test
+xenial*|test


### PR DESCRIPTION
I tried it on a HP chromebook 14, with targets `xfce,extension,keyboard` it installs and starts just fine. Audio is working, clipboard sync not. I also tested unity. Normal unity target will fail to install, because of no unity-2d package anymore. unity-desktop will install. However on both targets, the unity desktop will fail to start. This will need some work.  
I think people can better start testing xenial, since it is going to be the next lts release and we do want to support that. Maybe remove test from vivid and wily?