### PR TITLE
Updated echo_color function to support a second uncolored string.

### DIFF
--- a/installer/functions
+++ b/installer/functions
@@ -225,11 +225,11 @@ echo_tty() {
 }
 
 # Outputs colored text to stdout
-# usage: echo_color [l][color] [string]
+# usage: echo_color [l][color] [colored string] [uncolored string]
 # Specifying "t" (thick) uses bold text.
 # Color can be red, green, yellow, blue, magenta, cyan.
-# Color can be specified with just the first letter. 
-# example: echo_color "tr" "bold red"
+# Color can be specified with just the first letter.
+# example: echo_color "tr" "bold red" "normal text"
 echo_color() {
     # If not outputting to a tty print no colors.
     if [ ! -t 2 ]; then
@@ -260,8 +260,11 @@ echo_color() {
         s=''
         shift
     fi
+    echo '-n' "$1"
+    printf "\033[0m"
+    shift
     echo '-n' "$*"
-    printf "\033[0m$s"
+    printf "$s"
 }
 
 # Websocket interface


### PR DESCRIPTION
Now we can just use `echo_color "m" "Warning:" " what ever you have to warn the user about in uncolored text"`
