### PR TITLE
Fix package management error during xenial, wily setup

### DIFF
--- a/targets/gnome
+++ b/targets/gnome
@@ -10,7 +10,7 @@ CHROOTBIN='crouton-noroot startgnome gnome-session-wrapper'
 
 ### Append to prepare.sh:
 install --minimal evolution-data-server gnome-control-center \
-        gnome-screensaver gnome-session gnome-session-fallback \
+        gnome-screensaver gnome-session gnome-session-flashback \
         gnome-shell gnome-themes-standard gvfs-backends nautilus \
         unzip gtk2-engines-pixbuf
 

--- a/targets/gnome
+++ b/targets/gnome
@@ -8,9 +8,15 @@ HOSTBIN='startgnome'
 CHROOTBIN='crouton-noroot startgnome gnome-session-wrapper'
 . "${TARGETSDIR:="$PWD"}/common"
 
+if release -ge wheezy -ge kali -ge trusty; then
+  legacy_session_package="gnome-session-flashback"
+else
+  legacy_session_package="gnome-session-fallback"
+fi
+
 ### Append to prepare.sh:
 install --minimal evolution-data-server gnome-control-center \
-        gnome-screensaver gnome-session gnome-session-flashback \
+        gnome-screensaver gnome-session $legacy_session_package \
         gnome-shell gnome-themes-standard gvfs-backends nautilus \
         unzip gtk2-engines-pixbuf
 


### PR DESCRIPTION
"Error: Package gnome-session-fallback has no installation candidate" ― then a note that it has been replaced with gnome-session-flashback, so proposing a change to target script to reflect this