### PR TITLE
Allow `enabled_` boolean to persist in extension

### DIFF
--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -51,8 +51,9 @@ var notifications_ = {}; /* Map of notification id to function to be called when
 
 /* Check local storage for enabled option and set,
  * Otherwise default to true */
-chrome.storage.local.get("enabled", function(items){
+chrome.storage.local.get(null, function(items){
     enabled_ = (typeof items.enabled == "boolean" ? items.enabled : true);
+    hidpi_ = (typeof items.hidpi == "boolean" ? items.hidpi : false);
     refreshUI();
 });
 
@@ -215,6 +216,8 @@ function refreshUI() {
             if (window.devicePixelRatio > 1) {
                 hidpicheck.onclick = function() {
                     hidpi_ = hidpicheck.checked;
+                    /* Update local storage to persist hidpi_ setting */
+                    chrome.storage.local.set({hidpi: hidpi_});
                     refreshUI();
                     var disps = Object.keys(kiwi_win_);
                     for (var i = 0; i < disps.length; i++) {

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -52,7 +52,8 @@ var notifications_ = {}; /* Map of notification id to function to be called when
 /* Check local storage for enabled option and set,
  * Otherwise default to true */
 chrome.storage.local.get("enabled", function(items){
-    enabled_ = (items.enabled ? items.enabled : true);
+    enabled_ = (typeof items.enabled == "boolean" ? items.enabled : true);
+    refreshUI();
 });
 
 /* Set the current status string.

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -49,8 +49,7 @@ var focus_win_ = -1; /* Focused kiwi window. -1 if no kiwi window focused. */
 var notifications_ = {}; /* Map of notification id to function to be called when
                             the notification is clicked. */
 
-/* Check local storage for enabled option and set,
- * Otherwise default to true */
+/* Check local storage for stored options */
 chrome.storage.local.get(null, function(items){
     enabled_ = (typeof items.enabled == "boolean" ? items.enabled : true);
     hidpi_ = (typeof items.hidpi == "boolean" ? items.hidpi : false);

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -51,8 +51,8 @@ var notifications_ = {}; /* Map of notification id to function to be called when
 
 /* Check local storage for stored options */
 chrome.storage.local.get(null, function(items){
-    enabled_ = (typeof items.enabled == "boolean" ? items.enabled : true);
-    hidpi_ = (typeof items.hidpi == "boolean" ? items.hidpi : false);
+    if (typeof items.enabled == "boolean") enabled_ = items.enabled;
+    if (typeof items.hidpi == "boolean") hidpi_ = items.hidpi;
     refreshUI();
 });
 

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -49,6 +49,12 @@ var focus_win_ = -1; /* Focused kiwi window. -1 if no kiwi window focused. */
 var notifications_ = {}; /* Map of notification id to function to be called when
                             the notification is clicked. */
 
+/* Check local storage for enabled option and set,
+ * Otherwise default to true */
+chrome.storage.local.get("enabled", function(items){
+    enabled_ = (items.enabled ? items.enabled : true);
+});
+
 /* Set the current status string.
  * active is a boolean, true if the WebSocket connection is established. */
 function setStatus(status, active) {
@@ -162,6 +168,8 @@ function refreshUI() {
                 enablelink.onclick = function() {
                     console.log("Disable click");
                     enabled_ = false;
+                    /* Update local storage to persist enabled_ boolean */
+                    chrome.storage.local.set({enabled: enabled_});
                     if (websocket_ != null)
                         websocket_.close();
                     else
@@ -173,6 +181,8 @@ function refreshUI() {
                 enablelink.onclick = function() {
                     console.log("Enable click");
                     enabled_ = true;
+                    /* Update local storage to persist enabled_ boolean */
+                    chrome.storage.local.set({enabled: enabled_});
                     if (websocket_ == null)
                         websocketConnect();
                     refreshUI();

--- a/host-ext/crouton/manifest.json
+++ b/host-ext/crouton/manifest.json
@@ -25,6 +25,7 @@
   "permissions": [
     "clipboardRead",
     "clipboardWrite",
-    "notifications"
+    "notifications",
+    "storage"
   ]
 }


### PR DESCRIPTION
I sometimes have two accounts logged in to Chrome OS at the same time. They both have the crouton extension installed. When I start crouton using xiwi it connects to whichever account happens to catch it first. I can avoid this by disabling one or the other account's crouton extension. The problem is that the option doesn't persist across logins. I have added the `storage` permission to the manifest to allow for the `enabled_` boolean to persist, and also calls to `chrome.storage.local.set` and `chrome.storage.local.get` to set the option when changed and to get the option when the extension is loaded.