### PR TITLE
add support for kali linux rolling releases

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,3 +35,4 @@ Tobbe Lundberg
 Tony Xue
 Yu-Hsi Chiang
 Yuri Pole
+Aaron Zauner

--- a/installer/kali/releases
+++ b/installer/kali/releases
@@ -1,2 +1,3 @@
 kali*
 sana
+kali-rolling

--- a/installer/kali/releases
+++ b/installer/kali/releases
@@ -1,3 +1,3 @@
 kali*
-sana
+sana*
 kali-rolling


### PR DESCRIPTION
Kali recently switched to a rolling release model: https://www.kali.org/news/kali-linux-rolling-edition-2016-1/

(CLA signed, added myself to `CONTRIBUTORS`)