### PR TITLE
if netsurf-gtk not available, continue without it

### DIFF
--- a/targets/gtk-extra
+++ b/targets/gtk-extra
@@ -8,12 +8,16 @@ DESCRIPTION='GTK-based tools including gdebi, gksu, and a simple browser.'
 
 ### Append to prepare.sh:
 install_dummy network-manager network-manager-gnome
-install gdebi gksu netsurf-gtk
+install gdebi gksu
 
-# Add netsurf-gtk to Debian-alternatives if not already there
-netsurf='/usr/bin/netsurf-gtk'
-for link in x-www-browser gnome-www-browser; do
-    if ! update-alternatives --query "$link" | grep -q "$netsurf"; then
-        update-alternatives --install "/usr/bin/$link" "$link" "$netsurf" 10
+for BROWSER in netsurf-gtk dillo hv3 ""; do
+    if install ${BROWSER}; then
+        EXECUTABLE="/usr/bin/${BROWSER}"
+        for link in x-www-browser gnome-www-browser; do
+            if ! update-alternatives --query "$link" | grep -q "$EXECUTABLE"; then
+                update-alternatives --install "/usr/bin/$link" "$link" "$EXECUTABLE" 10
+            fi
+        done
+        break
     fi
 done


### PR DESCRIPTION
Continue the installation without it if nesurf-gtk is not an available package.

Crouton fails to create a chroot if the netsurf-gtk package is not available.

netsurf-gtk is not available in certain debian releases, including jessie and stretch as of 4/1/16.