### PR TITLE
LXQT

### DIFF
--- a/chroot-bin/startlxqt
+++ b/chroot-bin/startlxqt
@@ -1,0 +1,1 @@
+crouton-noroot

--- a/host-bin/startlxqt
+++ b/host-bin/startlxqt
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+APPLICATION="${0##*/}"
+
+USAGE="$APPLICATION [options]
+
+Wraps enter-chroot to start an LXQT session.
+By default, it will log into the primary user on the first chroot found.
+
+Options are directly passed to enter-chroot; run enter-chroot to list them."
+
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t lxqt "$@" "" \
+    exec xinit /usr/bin/startlxqt

--- a/targets/lxqt
+++ b/targets/lxqt
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
+   if release -lt trusty; then
+       error 99 "LXQT packages are not available for Ubuntu releases prior to xenial."
+   fi
+   if release -lt stretch; then
+       error 99 "LXQT packages are not available for Debian releases prior to stretch."
+   fi
+   if release -lt kali-rolling; then
+       error 99 "LXQT packages are not available for Kali Linux prior to kali-rolling."
+   fi
+fi
+
+REQUIRES='x11'
+DESCRIPTION='Installs the LXQT desktop environment. (Approx. 1GB)'
+HOSTBIN='startlxqt'
+CHROOTBIN='crouton-noroot startlxqt'
+. "${TARGETSDIR:="$PWD"}/common"
+
+### Append to prepare.sh:
+install lxqt lxqt-common openbox
+
+TIPS="$TIPS
+You can start LXQT via the startlxqt host command: sudo startlxqt
+"

--- a/test/tests/x0-alltargets
+++ b/test/tests/x0-alltargets
@@ -26,7 +26,7 @@ for target in "$SCRIPTDIR/targets/"*; do
     # Some other targets do not require testing in this context,
     # or have their own w* tests
     for blacklist in audio core x11 xephyr xiwi xorg \
-                     e17 gnome kde lxde unity xbmc xfce; do
+                     e17 gnome kde lxde lxqt unity xbmc xfce; do
         if [ "$target" = "$blacklist" ]; then
             break
         fi


### PR DESCRIPTION
This adds the target: lxqt

It consists of lxqt, lxqt-common and dependent packages which are ~32MB installed.

These packages are available only on ubuntu vivid and xenial currently.

It depends on gtk-extra for a browser.
