### PR TITLE
Mate

### DIFF
--- a/host-bin/startmate
+++ b/host-bin/startmate
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+APPLICATION="${0##*/}"
+
+USAGE="$APPLICATION [options]
+
+Wraps enter-chroot to start an MATE session.
+By default, it will log into the primary user on the first chroot found.
+
+Options are directly passed to enter-chroot; run enter-chroot to list them."
+
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t mate "$@" "" \
+    exec xinit /usr/bin/mate-session

--- a/targets/mate
+++ b/targets/mate
@@ -21,10 +21,19 @@ HOSTBIN='startmate'
 CHROOTBIN='crouton-noroot startmate'
 . "${TARGETSDIR:="$PWD"}/common"
 
+EXTRAPACKAGES=
+
 if release -le precise ; then
     install software-properties-common
     sudo apt-add-repository -y "deb http://packages.mate-desktop.org/repo/ubuntu precise main"
     sudo apt-get update
+fi
+
+if release -ge xenial ; then
+    install software-properties-common
+    sudo apt-add-repository -y ppa:ubuntu-mate-dev/xenial-mate
+    sudo apt-get update
+    EXTRAPACKAGES="${EXTRAPACKAGES} caja-actions ubuntu-mate-artwork"
 fi
 
 if release -eq trusty && [ "$ARCH" = 'amd64' -o "$ARCH" = 'i386' ]; then
@@ -34,7 +43,8 @@ if release -eq trusty && [ "$ARCH" = 'amd64' -o "$ARCH" = 'i386' ]; then
     sudo apt-get update
 fi
 
-install mate-desktop-environment
+
+install mate-desktop-environment ${EXTRAPACKAGES}
 
 TIPS="$TIPS
 You can start mate via the startmate host command: sudo startmate

--- a/targets/mate
+++ b/targets/mate
@@ -1,0 +1,41 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if [ "${TARGETNOINSTALL:-c}" = 'c' ]
+   if release -lt trusty; then
+       error 99 "Mate packages are not available for Ubuntu releases prior to trusty."
+   fi
+   if release -lt jessie; then
+       error 99 "Mate packages are not available for Debian releases prior to jessie."
+   fi
+   if release -lt sana; then
+       error 99 "Mate packages are not available for Kali Linux prior to sana."
+   fi
+fi
+
+REQUIRES='x11'
+DESCRIPTION='Installs the mate desktop environment. (Approx. 205MB)'
+HOSTBIN='startmate'
+CHROOTBIN='crouton-noroot startmate'
+. "${TARGETSDIR:="$PWD"}/common"
+
+if release -le precise ; then
+    install software-properties-common
+    sudo apt-add-repository -y "deb http://packages.mate-desktop.org/repo/ubuntu precise main"
+    sudo apt-get update
+fi
+
+if release -eq trusty && [ "$ARCH" = 'amd64' -o "$ARCH" = 'i386' ]; then
+    install software-properties-common
+    sudo apt-add-repository -y ppa:ubuntu-mate-dev/ppa
+    sudo apt-add-repository -y ppa:ubuntu-mate-dev/trusty-mate
+    sudo apt-get update
+fi
+
+install mate-desktop-environment
+
+TIPS="$TIPS
+You can start mate via the startmate host command: sudo startmate
+"

--- a/targets/mate
+++ b/targets/mate
@@ -36,7 +36,7 @@ if release -ge xenial ; then
     EXTRAPACKAGES="${EXTRAPACKAGES} caja-actions ubuntu-mate-artwork"
 fi
 
-if release -eq trusty && [ "$ARCH" = 'amd64' -o "$ARCH" = 'i386' ]; then
+if release -eq trusty ; then
     install software-properties-common
     sudo apt-add-repository -y ppa:ubuntu-mate-dev/ppa
     sudo apt-add-repository -y ppa:ubuntu-mate-dev/trusty-mate

--- a/targets/mate
+++ b/targets/mate
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-if [ "${TARGETNOINSTALL:-c}" = 'c' ]
+if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
    if release -lt trusty; then
        error 99 "Mate packages are not available for Ubuntu releases prior to trusty."
    fi

--- a/test/tests/x0-alltargets
+++ b/test/tests/x0-alltargets
@@ -26,7 +26,7 @@ for target in "$SCRIPTDIR/targets/"*; do
     # Some other targets do not require testing in this context,
     # or have their own w* tests
     for blacklist in audio core x11 xephyr xiwi xorg \
-                     e17 gnome kde lxde unity xbmc xfce; do
+                     e17 gnome kde lxde unity xbmc xfce mate; do
         if [ "$target" = "$blacklist" ]; then
             break
         fi


### PR DESCRIPTION
this adds the target 'mate' consisting of the mate-desktop-environment package, available on most ubuntu releases, and debian jessie and newer.
