### PR TITLE
targets/xorg: Do not install xserver-xorg-input-vmmouse

### DIFF
--- a/targets/xorg
+++ b/targets/xorg
@@ -190,7 +190,8 @@ if [ -z "$inteldriver" -a -n "$backport" ] && release -eq precise; then
         x11-xserver-utils xauth xinit xfonts-utils xkb-data xorg-docs-core \
         xterm x11-common xinput
 else
-    install xorg $installvideodrivers -- xserver-xorg-video-all$backport
+    install xorg $installvideodrivers -- xserver-xorg-video-all$backport \
+        xserver-xorg-input-vmmouse
 fi
 
 # Remove bad video drivers


### PR DESCRIPTION
The post-install hook of that package runs:
`udevadm trigger --subsystem-match=input --action=change`
which locks the input on Chrome OS side...

TEST=`sh crouton -r trusty -t xfce`

Fixes #1994.