### PR TITLE
targets/audio: Define CRAS_SOCKET_FILE_DIR

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -151,6 +151,8 @@ END
             convert_automake
 
             echo '
+                CFLAGS="$CFLAGS -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\""
+
                 buildlib libcras
 
                 # Pass -rpath=$CRASLIBDIR to linker, so we do not need to add


### PR DESCRIPTION
Since upstream commit 8d225aa3ef953f235d788509a0ba23b1f6504a5d "CRAS: Make socket directory configurable.", we need to define CRAS_SOCKET_FILE_DIR="/var/run/cras" manually.

Fixes #2583.