### PR TITLE
Fix issue when SELinux is enabled

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -528,6 +528,10 @@ if ! mountpoint -q "$CHROOT/sys"; then
     mount --make-rshared /sys
     mount --rbind /sys "$CHROOT/sys"
     mount --make-rslave "$CHROOT/sys"
+    # Remount selinux as ro
+    if [ -d "$CHROOT/sys/fs/selinux" ]; then
+        mount -o remount,ro "$CHROOT/sys/fs/selinux"
+    fi
 fi
 
 # Modify chroot's /sys/class/drm to avoid vgem


### PR DESCRIPTION
Remounting the directory as read-only appears to make the chroot believe that SELinux is disabled.