### PR TITLE
Fix abnormal termination at calling readlink in croutonfindnacl.

### DIFF
--- a/chroot-bin/croutonfindnacl
+++ b/chroot-bin/croutonfindnacl
@@ -52,7 +52,7 @@ for pid in $PIDS; do
 
     # Iterate over mappings, and check signature
     for fd in "/proc/$pid/fd"/*; do
-        link="`readlink -- "$fd"`"
+        link="$(readlink -- "$fd" || true)"
         link="${link% (deleted)}"
         if [ "$link" = "$file" ]; then
             # Check if signature matches


### PR DESCRIPTION
This patch is for fixing #2181.
In some situations, grabbed files in `/proc` are deleted before `readlink` calls.
In such case, `croutonfindnacl` is exited with its error code 1.
They may be caused by heavy CPU load, many file accesses.

The patch is adding `set +e / set -e` and explicit error checking around `readlink`.
