### PR TITLE
`sudo bash enter-chroot` doesn't mount Downloads

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -502,7 +502,7 @@ if [ -z "$NOLOGIN" -a -f "$shares" ]; then
                 continue;;
         esac
         # Expand dest for homedirs
-        if [ "${dest#~}" != "$dest" ]; then
+        if [ "${dest#"~"}" != "$dest" ]; then
             destuser="${dest%%/*}"
             if [ "$destuser" = '~' ]; then
                 if [ -z "$CHROOTHOME" ]; then
@@ -511,7 +511,7 @@ if [ -z "$NOLOGIN" -a -f "$shares" ]; then
                 fi
                 dest="$CHROOTHOME/${dest#*/}"
             else
-                dest="/home/${destuser#~}/${dest#*/}"
+                dest="/home/${destuser#"~"}/${dest#*/}"
             fi
         fi
         # Do the bindmount


### PR DESCRIPTION
For some reason, `startlxde` (and I assume others) properly substitute
`~` before mounting Downloads, however just calling `enter-chroot`
does not. After escaping the `~`, both `startlxde` and `enter-chroot`
work as expected.