### PR TITLE
support for release names with a dash in it, such as 'kali-rolling'

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -250,7 +250,7 @@ if [ -z "$DOWNLOADONLY" -a -n "$TARBALL" ]; then
         releasearch="${releasearch%%/*}"
     fi
     if [ "${releasearch#*-}" != "$releasearch" ]; then
-        ARCH="${releasearch#*-}"
+        ARCH="${releasearch##*-}"
         RELEASE="${releasearch%-*}"
     else
         RESTORE='y'


### PR DESCRIPTION
Resolves issue #2638 .