### PR TITLE
Fix ARC / Google Play for Chrome OS crash when starting chroot

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -528,10 +528,10 @@ if ! mountpoint -q "$CHROOT/sys"; then
     mount --make-rshared /sys
     mount --rbind /sys "$CHROOT/sys"
     mount --make-rslave "$CHROOT/sys"
-    # Remount selinux as ro
-    if [ -d "$CHROOT/sys/fs/selinux" ]; then
-        mount -o remount,ro "$CHROOT/sys/fs/selinux"
-    fi
+    # Mounting selinuxfs, remounted as RO or not, causes
+    # ARC / "Google Play for Chrome OS" to crash. The break
+    # is permanent until a clean reboot.
+    umount $CHROOT/sys/fs/selinux
 fi
 
 # Modify chroot's /sys/class/drm to avoid vgem

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -531,7 +531,9 @@ if ! mountpoint -q "$CHROOT/sys"; then
     # Mounting selinuxfs, remounted as RO or not, causes
     # ARC / "Google Play for Chrome OS" to crash. The break
     # is permanent until a clean reboot.
-    umount "$CHROOT/sys/fs/selinux"
+    if [ -d "$CHROOT/sys/fs/selinux" ]; then
+    	umount "$CHROOT/sys/fs/selinux" 2>/dev/null
+    fi
 fi
 
 # Modify chroot's /sys/class/drm to avoid vgem

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -531,7 +531,7 @@ if ! mountpoint -q "$CHROOT/sys"; then
     # Mounting selinuxfs, remounted as RO or not, causes
     # ARC / "Google Play for Chrome OS" to crash. The break
     # is permanent until a clean reboot.
-    umount $CHROOT/sys/fs/selinux
+    umount "$CHROOT/sys/fs/selinux"
 fi
 
 # Modify chroot's /sys/class/drm to avoid vgem


### PR DESCRIPTION
This fixes issue #2706 .

* Remounting the selinuxfs mountpoint /sys/fs/selinux in the chroot as
  read-only doesn't seem to offer the protection one would expect.
* This fix assumes there is no direct need for use of SELinux within
  the chroot (and besides, wouldn't /etc/selinux need to be bind
  mounted, too?)
* TL;DR This fixes the ARC / Google Play breakage when using crouton.