### PR TITLE
Add Yakkety as a supported release

### DIFF
--- a/installer/ubuntu/releases
+++ b/installer/ubuntu/releases
@@ -22,3 +22,4 @@ utopic*
 vivid*
 wily*|test
 xenial*|test
+yakkety*|test


### PR DESCRIPTION
More often than not, I find myself installing a Xenial chroot then upgrading to Yakkety. This would be great to have.