### PR TITLE
Add synclient trackpad settings for lenovo13 'sentry'

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -113,7 +113,7 @@ if [ "$xmethodtype" != "xiwi" ]; then
     # Configure trackpad settings if needed
     if synclient >/dev/null 2>&1; then
         case "`awk -F= '/_RELEASE_BOARD=/{print $2}' '/var/host/lsb-release'`" in
-            butterfly*|falco*)
+            butterfly*|falco*|sentry*)
                 SYNCLIENT="FingerLow=1 FingerHigh=5 $SYNCLIENT";;
             parrot*|peppy*|wolf*)
                 SYNCLIENT="FingerLow=5 FingerHigh=10 $SYNCLIENT";;


### PR DESCRIPTION
Updating the synclient settings as advised in [#214](https://github.com/dnschneid/crouton/issues/214#) 

This is for the lenovo thinkpad 13.  I see there is a list of other machines there that need the fix as well but most of them don't have enough info for me to know which settings to put them under.