### PR TITLE
Acer Chromebook 14 (edgar) specific touchpad settings.

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -117,6 +117,11 @@ if [ "$xmethodtype" != "xiwi" ]; then
                 SYNCLIENT="FingerLow=1 FingerHigh=5 $SYNCLIENT";;
             parrot*|peppy*|wolf*)
                 SYNCLIENT="FingerLow=5 FingerHigh=10 $SYNCLIENT";;
+            edgar*)
+                SYNCLIENT="FingerLow=5 FingerHigh=10 LeftEdge=0 RightEdge=3240
+                TopEdge=0 BottomEdge=2352 HorizHysteresis=80 VertHysteresis=80
+                PalmMinWidth=10 PalmMinZ=0 AreaLeftEdge=0 AreaRightEdge=3240
+                $SYNCLIENT";;
         esac
         if [ -n "$SYNCLIENT" ]; then
             synclient $SYNCLIENT


### PR DESCRIPTION
The following PR should fix the touchpad problems mentioned in issue #2657.

I've chosen to implement a custom path as I felt setting `FingerLow` and `FingerHigh` alone didn't offer a sufficient enough usability improvement.
