### PR TITLE
Add support for aarch64

### DIFF
--- a/installer/debian/defaults
+++ b/installer/debian/defaults
@@ -14,7 +14,7 @@ case "$ARCH" in
 x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
 armel) ARCH="armel";;
-arm*) ARCH="armhf";;
+arm* | aarch64) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;
 esac
 

--- a/installer/kali/defaults
+++ b/installer/kali/defaults
@@ -13,7 +13,7 @@ fi
 case "$ARCH" in
 x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
-arm*) ARCH="armhf";;
+arm* | aarch64) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;
 esac
 

--- a/installer/ubuntu/defaults
+++ b/installer/ubuntu/defaults
@@ -13,7 +13,7 @@ fi
 case "$ARCH" in
 x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
-arm*) ARCH="armhf";;
+arm* | aarch64) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;
 esac
 


### PR DESCRIPTION
Currently, these platforms use 32-bit userspace, so let's just map aarch64 to armhf.