### PR TITLE
enter-chroot: Unmount /sys/fs/selinux, remount fake directory

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -537,9 +537,12 @@ if ! mountpoint -q "$CHROOT/sys"; then
     mount --make-rshared /sys
     mount --rbind /sys "$CHROOT/sys"
     mount --make-rslave "$CHROOT/sys"
-    # Remount selinux as ro
+    # Unmount selinux in the chroot, make a fake entry to set enforce=0
     if mountpoint -q "$CHROOT/sys/fs/selinux"; then
-        mount -o remount,ro,bind "$CHROOT/sys/fs/selinux"
+        umount "$CHROOT/sys/fs/selinux"
+        mount -t tmpfs none "$CHROOT/sys/fs/selinux"
+        echo 0 > "$CHROOT/sys/fs/selinux/enforce"
+        mount -o remount,ro "$CHROOT/sys/fs/selinux"
     fi
 fi
 


### PR DESCRIPTION
Fixes #2655.

We first unmount /sys/fs/selinux, which fixes a number of issues
(but not all).

Then, we create a fake, read-only, /sys/fs/selinux tmpfs, with
its enforce flag set to 0. This is necessary for precise to be able
to add users.

@rickyz: Any comment on this?