### PR TITLE
Fixed unity target install errors on ubuntu xenial

### DIFF
--- a/targets/unity
+++ b/targets/unity
@@ -17,9 +17,15 @@ CHROOTETC='unity-autostart.desktop unity-profiled'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-install unity unity-2d ubuntu-artwork gnome-session nautilus \
-        ubuntu-settings,ubuntu~precise= \
-        ubuntu-session,ubuntu~precise+ubuntu~quantal+ubuntu~raring+ubuntu~saucy= \
+# Note that whitespace is important for syntax...
+# See distropkgs method in installer/prepare.sh
+install unity ubuntu-artwork gnome-session nautilus \
+        `# unity-2d only exists on ubuntu trusty and precise.`\
+        ubuntu~trusty+ubuntu~precise=unity-2d, \
+        `# ubuntu-settings does not exist on ubuntu precise.`\
+        ubuntu~precise=,ubuntu-settings \
+        `# ubuntu-session does not exist on the following releases.`\
+      ubuntu~precise+ubuntu~quantal+ubuntu~raring+ubuntu~saucy=,ubuntu-session \
         -- network-manager brasero firefox
 
 # XDG autostart/profile.d additions only needed in saucy and later

--- a/targets/unity
+++ b/targets/unity
@@ -17,15 +17,12 @@ CHROOTETC='unity-autostart.desktop unity-profiled'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-# Note that whitespace is important for syntax...
+# Note that whitespace is important for syntax.
 # See distropkgs method in installer/prepare.sh
 install unity ubuntu-artwork gnome-session nautilus \
-        `# unity-2d only exists on ubuntu trusty and precise.`\
         ubuntu~trusty+ubuntu~precise=unity-2d, \
-        `# ubuntu-settings does not exist on ubuntu precise.`\
         ubuntu~precise=,ubuntu-settings \
-        `# ubuntu-session does not exist on the following releases.`\
-      ubuntu~precise+ubuntu~quantal+ubuntu~raring+ubuntu~saucy=,ubuntu-session \
+        ubuntu~precise+ubuntu~quantal+ubuntu~raring+ubuntu~saucy=,ubuntu-session \
         -- network-manager brasero firefox
 
 # XDG autostart/profile.d additions only needed in saucy and later


### PR DESCRIPTION
unity-2d doesn't exist in xenial's repository, which had caused chroot installation errors.

Even though the install works now, unity does not automatically start with gnome-session, and several applications are broken upon starting unity manually.

At least it's a start.

Issues addressed but not fully fixed:
https://github.com/dnschneid/crouton/issues/2771
https://github.com/dnschneid/crouton/issues/2720

Personally, I would like to have support for 16.04, as it's an LTS release. Since trusty, much has changed, though crouton has yet to reflect those changes.

Unfortunately, I don't think my knowledge of Ubuntu's workings is enough for me to singlehandedly add support for an OS. If anyone is interested, please help!
