### PR TITLE
ubuntu/prepare: Fix install_dist to throw an error when apt-get fails

### DIFF
--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -33,7 +33,7 @@ install_dist() {
     if [ -n "$asdeps" ]; then
         pkgsasdeps="`list_uninstalled_dist '' $pkgs`"
     fi
-    apt-get -y $params install $pkgs `list_uninstalled_dist - "$@"`
+    apt-get -y $params install $pkgs `list_uninstalled_dist - "$@"` || return $?
     if [ -n "$pkgsasdeps" ]; then
         apt-mark auto $pkgsasdeps
     fi
@@ -48,7 +48,7 @@ install_pkg_dist() {
         shift
     fi
     if [ ! "$#" = 0 ]; then
-        dpkg --force-depends -i "$@"
+        dpkg --force-depends -i "$@" || return $?
     fi
     apt-get -fy $params install
 }


### PR DESCRIPTION
Makes #2516 work fine.