### PR TITLE
35-xorg: Do not try to run on wheezy, remove references to non-freonized exynos

### DIFF
--- a/test/tests/35-xorg
+++ b/test/tests/35-xorg
@@ -5,7 +5,12 @@
 
 # All supported releases should be able to launch an xorg server
 if [ -z "$release" ]; then
-    echo "all"
+    # xorg does not work well on wheezy
+    for rel in $SUPPORTED_RELEASES; do
+        if [ "$rel" != wheezy ]; then
+            echo "$rel"
+        fi
+    done
     exit 0
 fi
 


### PR DESCRIPTION
Fixes #2012.