### PR TITLE
core: add LANG to default locale

### DIFF
--- a/targets/core
+++ b/targets/core
@@ -114,6 +114,7 @@ install --minimal sudo wget ca-certificates apt-transport-https
 
 # Generate and set default locale
 if [ ! -f '/etc/default/locale' ] && hash locale-gen 2>/dev/null; then
+    echo 'LANG=en_US.UTF-8' > '/etc/default/locale'
     locale-gen --lang en_US.UTF-8
     if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
         dpkg-reconfigure locales


### PR DESCRIPTION
Imma let you finish, but en_US.UTF-8 is the
one of the best locales of all time.