### PR TITLE
Set default release to xenial

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -31,7 +31,8 @@ PROXY='unspecified'
 RELEASE=''
 RESTORE=''
 RESTOREBIN=''
-DEFAULTRELEASE='precise'
+DEFAULTRELEASE='xenial'
+PREVIOUS_DEFAULT_RELEASES='precise'
 TARBALL=''
 TARGETS=''
 TARGETFILE=''
@@ -368,6 +369,15 @@ CHROOTS="$PREFIX/chroots"
 
 if [ -z "$RESTOREBIN" ]; then
     # Fix NAME if it was not specified.
+    # If updating and name/release weren't specified, check previous defaults
+    if [ -n "$UPDATE" -a -z "$NAME$RELEASE" ]; then
+        for rel in "$DEFAULTRELEASE" $PREVIOUS_DEFAULT_RELEASES; do
+            if [ -d "$CHROOTS/$rel" ]; then
+                DEFAULTRELEASE="$rel"
+                break
+            fi
+        done
+    fi
     CHROOT="$CHROOTS/${NAME:="${RELEASE:-"$DEFAULTRELEASE"}"}"
     CHROOTSRC="$CHROOT"
 fi

--- a/installer/ubuntu/releases
+++ b/installer/ubuntu/releases
@@ -21,6 +21,6 @@ trusty
 utopic*
 vivid*
 wily*
-xenial*|test
+xenial
 yakkety*|test
 zesty*|test


### PR DESCRIPTION
Fall back and check precise on updates if xenial doesn't exist.

Of course, this should only get merged once the other xenial bugs/PRs are fixed.
