### PR TITLE
install "www-browser" symlink as well

### DIFF
--- a/targets/extension
+++ b/targets/extension
@@ -36,7 +36,7 @@ fi
 
 # Use croutonurlhandler as a fallback URL handler
 handler='/usr/local/bin/croutonurlhandler'
-for link in x-www-browser gnome-www-browser; do
+for link in x-www-browser gnome-www-browser www-browser; do
     if ! update-alternatives --query "$link" | grep -q "$handler"; then
         update-alternatives --install "/usr/bin/$link" "$link" "$handler" 15
     fi


### PR DESCRIPTION
In the terminal, as with e.g. targets *xiwi* and *cli-extra*, tools such as `xdg-open` can't find a `$DISPLAY`, so they attempt to execute `www-browser` rather than `x-www-browser`. So, that symlink should also exist.