### PR TITLE
A simple non-intrusive solution to bug #1638

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -723,6 +723,8 @@ done
 
 if [ -f "$PREPARE" ]; then
     # Update .crouton-targets in the unencrypted part of the chroot
+    # First create the file if it is not there
+    touch "$CHROOTSRC/.crouton-targets"
     cp -fT "$TARGETDEDUPFILE" "$CHROOTSRC/.crouton-targets"
 
     chmod 500 "$PREPARE"


### PR DESCRIPTION
In line 727, we touch "$CHROOTSRC/.crouton-targets" to make sure it exists before using it in the next line.