### PR TITLE
Small fix for edgar touchpad support

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -104,7 +104,7 @@ if [ "$xmethodtype" != "xiwi" ]; then
     # Configure trackpad settings if needed
     if synclient >/dev/null 2>&1; then
         case "`awk -F= '/_RELEASE_BOARD=/{print $2}' '/var/host/lsb-release'`" in
-            butterfly*|falco*|sentry*|edgar*)
+            butterfly*|falco*|sentry*|edgar*|chell*|terra*|reks*)
                 SYNCLIENT="FingerLow=1 FingerHigh=5 $SYNCLIENT";;
             parrot*|peppy*|wolf*)
                 SYNCLIENT="FingerLow=5 FingerHigh=10 $SYNCLIENT";;

--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -104,7 +104,7 @@ if [ "$xmethodtype" != "xiwi" ]; then
     # Configure trackpad settings if needed
     if synclient >/dev/null 2>&1; then
         case "`awk -F= '/_RELEASE_BOARD=/{print $2}' '/var/host/lsb-release'`" in
-            butterfly*|falco*|sentry*)
+            butterfly*|falco*|sentry*|edgar*)
                 SYNCLIENT="FingerLow=1 FingerHigh=5 $SYNCLIENT";;
             parrot*|peppy*|wolf*)
                 SYNCLIENT="FingerLow=5 FingerHigh=10 $SYNCLIENT";;


### PR DESCRIPTION
Edgar is a new chromebook model, this fixes low responsiveness on the synaptic touchpad.
I think all newer models have higher touchpad resolution so maybe a better solution would be to send the "default" case to FingerLow=1 FingerHigh=5.