### PR TITLE
Allow aarch64 chroots

### DIFF
--- a/installer/ubuntu/defaults
+++ b/installer/ubuntu/defaults
@@ -13,7 +13,8 @@ fi
 case "$ARCH" in
 x86 | i?86) ARCH="i386";;
 x86_64 | amd64) ARCH="amd64";;
-arm* | aarch64) ARCH="armhf";;
+aarch64) ARCH="aarch64";;
+arm*) ARCH="armhf";;
 *) error 2 "Invalid architecture '$ARCH'.";;
 esac
 


### PR DESCRIPTION
With introduction of acer R13 chromebook, we now have 64-bit capable hardware for ARM.  Let's use it.

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>