### PR TITLE
Added gtk2-engines-pixbuf to remove warnings in XFCE

### DIFF
--- a/targets/xfce
+++ b/targets/xfce
@@ -31,7 +31,7 @@ cat > '/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml' <<EOF
 EOF
 
 install xfce4 xfce4-goodies ubuntu=shimmer-themes, \
-        -- dictionaries-common hddtemp xorg
+        -- dictionaries-common hddtemp xorg gtk2-engines-pixbuf
 
 TIPS="$TIPS
 You can start Xfce via the startxfce4 host command: sudo startxfce4


### PR DESCRIPTION
I get the following warning messages on the xfce target after `sudo startxfce4`:
```
(xfsettingsd:21732): Gtk-WARNING **: Unable to locate theme engine in module_path: "pixmap",
(xfsettingsd:21732): Gtk-WARNING **: Unable to locate theme engine in module_path: "pixmap",
(xfdesktop:21724): Gtk-WARNING **: Unable to locate theme engine in module_path: "pixmap",
```
According to [this askubuntu question](https://askubuntu.com/questions/66356/gdk-gtk-warnings-and-errors-from-the-command-line), one should install `gtk2-engines-pixbuf`. It is included by default in the gnome target but not the xfce target. Installing the package fixed the warnings for me.

I think `gtk2-engines-pixbuf` should be installed on xfce by default.