### PR TITLE
croutonfreon.so: Disable cursor on switch away from Chromium OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CFLAGS=-g -Wall -Werror -Os
 
 croutonfbserver_LIBS = -lX11 -lXdamage -lXext -lXfixes -lXtst
 croutonxi2event_LIBS = -lX11 -lXi
-croutonfreon.so_LIBS = -ldl
+croutonfreon.so_LIBS = -ldl -ldrm -I/usr/include/libdrm
 
 croutonwebsocket_DEPS = src/websocket.h
 croutonfbserver_DEPS = src/websocket.h

--- a/targets/xorg
+++ b/targets/xorg
@@ -91,7 +91,7 @@ fi
 
 # On Freon, we need crazy xorg hacks
 if [ -n "$freon" ]; then
-    compile freon '-ldl' so
+    compile freon '-ldl -ldrm -I/usr/include/libdrm' so libdrm-dev
 fi
 
 # Pin precise's version of mesa if necessary


### PR DESCRIPTION
For reasons that I do not fully comprehend, cursor sometimes get corrupted in crouton (see #2878, http://crbug.com/482801).

It does appears the resetting cursors on all CRTCs fixes the issue, so let's do that.