### PR TITLE
xiwi: patch with xf86-video-dummy-0.3.8

### DIFF
--- a/targets/xiwi
+++ b/targets/xiwi
@@ -261,15 +261,15 @@ index 2656602..0718e1f 100644
 -    /* Prune the modes marked as invalid */
 -    xf86PruneDriverModes(pScrn);
 +    output->possible_crtcs = 0x7f;
- 
+
 -    if (i == 0 || pScrn->modes == NULL) {
 +    xf86InitialConfiguration(pScrn, TRUE);
 +
 +    if (pScrn->depth > 1) {
-+      	Gamma zeros = {0.0, 0.0, 0.0};
-+        
-+        if (!xf86SetGamma(pScrn, zeros))
-+            return FALSE;
++	Gamma zeros = {0.0, 0.0, 0.0};
++
++	if (!xf86SetGamma(pScrn, zeros))
++	    return FALSE;
 +    }
 +
 +    if (pScrn->modes == NULL) {
@@ -297,14 +297,13 @@ index 2656602..0718e1f 100644
  
      /* If monitor resolution is set on the command line, use it */
      xf86SetDpi(pScrn, 0, 0);
--
-+    
+ 
 +    /* Set monitor size based on DPI */
 +    output->mm_width = pScrn->xDpi > 0 ?
-+    (pScrn->virtualX * 254 / (10*pScrn->xDpi)) : 0;
++        (pScrn->virtualX * 254 / (10*pScrn->xDpi)) : 0;
 +    output->mm_height = pScrn->yDpi > 0 ?
-+    (pScrn->virtualY * 254 / (10*pScrn->yDpi)) : 0;
-+    
++        (pScrn->virtualY * 254 / (10*pScrn->yDpi)) : 0;
++
      if (xf86LoadSubModule(pScrn, "fb") == NULL) {
  	RETURN;
      }

--- a/targets/xiwi
+++ b/targets/xiwi
@@ -52,7 +52,7 @@ addtrap "rm -rf --one-file-system '$DUMMYBUILDTMP'"
 
 echo "Download Xorg dummy driver..." 1>&2
 
-wget -O "$DUMMYBUILDTMP/dummy.tar.gz" "$urlbase/xf86-video-dummy-0.3.7.tar.gz"
+wget -O "$DUMMYBUILDTMP/dummy.tar.gz" "$urlbase/xf86-video-dummy-0.3.8.tar.gz"
 
 install --minimal --asdeps patch gcc libc-dev pkg-config \
     xserver-xorg-dev$ltspackages x11proto-xf86dga-dev
@@ -65,7 +65,7 @@ install --minimal --asdeps patch gcc libc-dev pkg-config \
     echo "Patching Xorg dummy driver (xrandr 1.2 support)..." 1>&2
     patch -p1 <<EOF
 diff --git a/src/dummy_driver.c b/src/dummy_driver.c
-index 6062c39..3414a6d 100644
+index 2656602..0718e1f 100644
 --- a/src/dummy_driver.c
 +++ b/src/dummy_driver.c
 @@ -34,6 +34,8 @@
@@ -77,7 +77,7 @@ index 6062c39..3414a6d 100644
  /*
   * Driver data structures.
   */
-@@ -178,6 +180,115 @@ dummySetup(pointer module, pointer opts, int *errmaj, int *errmin)
+@@ -175,6 +177,115 @@ dummySetup(pointer module, pointer opts, int *errmaj, int *errmin)
  #endif /* XFree86LOADER */
  
  static Bool
@@ -193,16 +193,16 @@ index 6062c39..3414a6d 100644
  DUMMYGetRec(ScrnInfoPtr pScrn)
  {
      /*
-@@ -283,6 +394,8 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
+@@ -280,6 +391,8 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
      DUMMYPtr dPtr;
-     int maxClock = 230000;
+     int maxClock = 300000;
      GDevPtr device = xf86GetEntityInfo(pScrn->entityList[0])->device;
 +    xf86OutputPtr output;
 +    xf86CrtcPtr crtc;
  
      if (flags & PROBE_DETECT) 
  	return TRUE;
-@@ -346,13 +459,6 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
+@@ -343,13 +456,6 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
      if (!xf86SetDefaultVisual(pScrn, -1)) 
  	return FALSE;
  
@@ -216,7 +216,7 @@ index 6062c39..3414a6d 100644
      xf86CollectOptions(pScrn, device->options);
      /* Process the options */
      if (!(dPtr->Options = malloc(sizeof(DUMMYOptions))))
-@@ -382,64 +488,45 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
+@@ -379,64 +485,45 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
  		   maxClock);
      }
  
@@ -229,7 +229,7 @@ index 6062c39..3414a6d 100644
 -    clockRanges->next = NULL;
 -    clockRanges->ClockMulFactor = 1;
 -    clockRanges->minClock = 11000;   /* guessed §§§ */
--    clockRanges->maxClock = 300000;
+-    clockRanges->maxClock = maxClock;
 -    clockRanges->clockIndex = -1;		/* programmable */
 -    clockRanges->interlaceAllowed = TRUE; 
 -    clockRanges->doubleScanAllowed = TRUE;
@@ -257,21 +257,21 @@ index 6062c39..3414a6d 100644
 +    crtc = xf86CrtcCreate(pScrn, &dummy_crtc_funcs);
 +
 +    output = xf86OutputCreate (pScrn, &dummy_output_funcs, "default");
-+
-+    output->possible_crtcs = 0x7f;
  
 -    /* Prune the modes marked as invalid */
 -    xf86PruneDriverModes(pScrn);
++    output->possible_crtcs = 0x7f;
+ 
+-    if (i == 0 || pScrn->modes == NULL) {
 +    xf86InitialConfiguration(pScrn, TRUE);
 +
 +    if (pScrn->depth > 1) {
-+	Gamma zeros = {0.0, 0.0, 0.0};
-+
-+	if (!xf86SetGamma(pScrn, zeros))
-+	    return FALSE;
++      	Gamma zeros = {0.0, 0.0, 0.0};
++        
++        if (!xf86SetGamma(pScrn, zeros))
++            return FALSE;
 +    }
- 
--    if (i == 0 || pScrn->modes == NULL) {
++
 +    if (pScrn->modes == NULL) {
  	xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "No valid modes found\n");
  	RETURN;
@@ -297,17 +297,18 @@ index 6062c39..3414a6d 100644
  
      /* If monitor resolution is set on the command line, use it */
      xf86SetDpi(pScrn, 0, 0);
- 
+-
++    
 +    /* Set monitor size based on DPI */
 +    output->mm_width = pScrn->xDpi > 0 ?
-+        (pScrn->virtualX * 254 / (10*pScrn->xDpi)) : 0;
++    (pScrn->virtualX * 254 / (10*pScrn->xDpi)) : 0;
 +    output->mm_height = pScrn->yDpi > 0 ?
-+        (pScrn->virtualY * 254 / (10*pScrn->yDpi)) : 0;
-+
++    (pScrn->virtualY * 254 / (10*pScrn->yDpi)) : 0;
++    
      if (xf86LoadSubModule(pScrn, "fb") == NULL) {
  	RETURN;
      }
-@@ -559,6 +646,8 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
+@@ -537,6 +624,8 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
  
      if (!miSetPixmapDepths ()) return FALSE;
  
@@ -316,7 +317,7 @@ index 6062c39..3414a6d 100644
      /*
       * Call the framebuffer layer's ScreenInit function, and fill in other
       * pScreen fields.
-@@ -597,23 +686,6 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
+@@ -575,23 +664,6 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
      if (dPtr->swCursor)
  	xf86DrvMsg(pScrn->scrnIndex, X_CONFIG, "Using Software Cursor.\n");
  
@@ -340,7 +341,7 @@ index 6062c39..3414a6d 100644
      xf86SetBackingStore(pScreen);
      xf86SetSilkenMouse(pScreen);
  	
-@@ -640,6 +712,9 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
+@@ -618,6 +690,9 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
  			     | CMAP_RELOAD_ON_MODE_SWITCH))
  	return FALSE;
  


### PR DESCRIPTION
Xiwi fails on distro sid and stretch due to:
`/usr/lib/xorg/Xorg: symbol lookup error: /usr/lib/xorg/modules/drivers/dummy_drv.so: undefined symbol: ChangeWindowProperty`
[https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845728](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845728)

Xiwi updated to patch from xf86-video-dummy-0.3.8 source to match
[https://packages.debian.org/source/sid/xserver-xorg-video-dummy](https://packages.debian.org/source/sid/xserver-xorg-video-dummy)

Works like a charm for sid, stretch. Also tested successfully on jessie (0.3.7-1) and wheezy (0.3.5-2) and since the package version was faked to 0.3.8 I believe we're good to go.