### PR TITLE
Create Android Studio target

### DIFF
--- a/host-bin/startandroidstudio
+++ b/host-bin/startandroidstudio
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+APPLICATION="${0##*/}"
+
+
+USAGE="$APPLICATION [options]
+Wraps enter-chroot to launch Android Studio in an xiwi window.
+By default, it will log into the primary user on the first chroot found.
+Options are directly passed to enter-chroot; run enter-chroot to list them."
+
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t android-studio "$@" "" \
+  exec xiwi -b /opt/google/android/studio/bin/studio.sh

--- a/host-bin/startandroidstudio
+++ b/host-bin/startandroidstudio
@@ -13,5 +13,4 @@ Wraps enter-chroot to launch Android Studio in an xiwi window.
 By default, it will log into the primary user on the first chroot found.
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t android-studio "$@" "" \
-  exec xiwi -b /opt/google/android/studio/bin/studio.sh
+exec startxiwi -b /opt/google/android/studio/bin/studio.sh

--- a/host-bin/startandroidstudio
+++ b/host-bin/startandroidstudio
@@ -13,5 +13,5 @@ Wraps enter-chroot to launch Android Studio in an xiwi window.
 By default, it will log into the primary user on the first chroot found.
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-eval "exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t android-studio "$@" "" \
-  exec xiwi -b /opt/google/android/studio/bin/studio.sh"
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t android-studio "$@" "" \
+  exec xiwi -b /opt/google/android/studio/bin/studio.sh

--- a/host-bin/startandroidstudio
+++ b/host-bin/startandroidstudio
@@ -13,5 +13,5 @@ Wraps enter-chroot to launch Android Studio in an xiwi window.
 By default, it will log into the primary user on the first chroot found.
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t android-studio "$@" "" \
-  exec xiwi -b /opt/google/android/studio/bin/studio.sh
+eval "exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t android-studio "$@" "" \
+  exec xiwi -b /opt/google/android/studio/bin/studio.sh"

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -24,7 +24,7 @@ if [ $DISTRO != "ubuntu" ]; then
      deb-src http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main
   EOF
 fi
-install ubuntu-make
+install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk ubuntu-make
 yes 'a' | umake android /opt/google/android/studio
 
 TIPS="$TIPS

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -4,14 +4,23 @@
 # found in the LICENSE file.
 
 REQUIRES='xiwi gtk-extra'
-DESCRIPTION='Installs Android Studio as an easily launchable xiwi application'
+DESCRIPTION='Installs Android Studio as a directly launchable xiwi application'
 HOSTBIN='startandroidstudio'
 
 ### Append to prepare.sh:
-mkdir /etc/bash-completion.d #Must do this in order to avoid package management error while installing umake
+# Must create the /etc/bash_completion.d directory
+# in order for umake to properly install
+mkdir /etc/bash_completion.d
 if [ $DISTRO != "ubuntu" ]; then
-  echo "deb http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main\n\
-     deb-src http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main" >> /etc/apt/sources.list
+  #Pull in the signing key
+  apt-key adv --keyserver 'keyserver.ubuntu.com' \
+                --recv-keys '07D44A5424C7C12A4BAB1E80EB563F93142986CE'
+  #Add the software source
+  cat > '/etc/apt/sources.list.d/umake.list' << EOF
+     # Bring in Umake PPA on non-Ubuntu distros
+     deb http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main
+     deb-src http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main
+  EOF
   install ubuntu-make
 else
   install ubuntu-make
@@ -19,5 +28,6 @@ fi
 yes 'a' | umake android /opt/google/android/studio
 
 TIPS="$TIPS
-You can run Android studio in a Chrome OS window via the startandroidstudio host command: sudo startandroidstudio
+You can run Android studio in a Chrome OS window
+via the startandroidstudio host command: sudo startandroidstudio
 "

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -8,9 +8,11 @@ DESCRIPTION='Installs Android Studio as a directly launchable xiwi application'
 HOSTBIN='startandroidstudio'
 
 ### Append to prepare.sh:
-# Must create the /etc/bash_completion.d directory
+# Must create the /etc/bash_completion.d directory on yakkety+
 # in order for umake to properly install
-mkdir /etc/bash_completion.d
+if [ $RELEASE == "yakkety" || $RELEASE == "zesty" ]; 
+  mkdir /etc/bash_completion.d
+fi
 if [ $DISTRO != "ubuntu" ]; then
   #Pull in the signing key
   apt-key adv --keyserver 'keyserver.ubuntu.com' \

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -25,7 +25,8 @@ if [ $DISTRO != "ubuntu" ]; then
   EOF
 fi
 install openjdk-8-jre openjdk-8-jdk ubuntu-make
-yes 'a' | umake android /opt/google/android/studio
+yes 'a' | umake android $HOME/Downloads/google/android/studio
+mv $HOME/Downloads/google /opt/
 
 TIPS="$TIPS
 You can run Android studio in a Chrome OS window

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -9,7 +9,13 @@ HOSTBIN='startandroidstudio'
 
 ### Append to prepare.sh:
 mkdir /etc/bash-completion.d #Must do this in order to avoid package management error while installing umake
-install ubuntu-make
+if [ $DISTRO != "ubuntu" ]; then
+  echo "deb http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main\n\
+     deb-src http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main" >> /etc/apt/sources.list
+  install ubuntu-make
+else
+  install ubuntu-make
+fi
 yes 'a' | umake android /opt/google/android/studio
 
 TIPS="$TIPS

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+REQUIRES='xiwi gtk-extra'
+DESCRIPTION='Installs Android Studio as an easily launchable xiwi application'
+HOSTBIN='startandroidstudio'
+
+### Append to prepare.sh:
+mkdir /etc/bash-completion.d #Must do this in order to avoid package management error while installing umake
+install ubuntu-make
+yes 'a' | umake android /opt/google/android/studio
+
+TIPS="$TIPS
+You can run Android studio in a Chrome OS window via the startandroidstudio host command: sudo startandroidstudio
+"

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -24,7 +24,7 @@ if [ $DISTRO != "ubuntu" ]; then
      deb-src http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main
   EOF
 fi
-install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk ubuntu-make
+install openjdk-8-jre openjdk-8-jdk ubuntu-make
 yes 'a' | umake android /opt/google/android/studio
 
 TIPS="$TIPS

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -23,10 +23,8 @@ if [ $DISTRO != "ubuntu" ]; then
      deb http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main
      deb-src http://ppa.launchpad.net/ubuntu-desktop/ubuntu-make/ubuntu yakkety main
   EOF
-  install ubuntu-make
-else
-  install ubuntu-make
 fi
+install ubuntu-make
 yes 'a' | umake android /opt/google/android/studio
 
 TIPS="$TIPS

--- a/targets/android-studio
+++ b/targets/android-studio
@@ -10,7 +10,7 @@ HOSTBIN='startandroidstudio'
 ### Append to prepare.sh:
 # Must create the /etc/bash_completion.d directory on yakkety+
 # in order for umake to properly install
-if [ $RELEASE == "yakkety" || $RELEASE == "zesty" ]; 
+if [ $RELEASE == "yakkety" || $RELEASE == "zesty" ]; then
   mkdir /etc/bash_completion.d
 fi
 if [ $DISTRO != "ubuntu" ]; then


### PR DESCRIPTION
Since it's rather difficult to manually get Android Studio ― the only reason why I in particular still use Crouton ― onto a Chromebook using Crouton without also installing a desktop environment and risking radically reducing the amount of available storage on a Chromebook, I decided it would be a great idea to actually create a target that installs Android Studio along with as little additional overhead as possible. First I got it installed; now it's time to share how I did it with the world.