### PR TITLE
Add Elementary Target

### DIFF
--- a/chroot-bin/startelementary
+++ b/chroot-bin/startelementary
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Launches ELEMENTARY
+
+exec crouton-noroot gnome-session-wrapper pantheon

--- a/host-bin/startelementary
+++ b/host-bin/startelementary
@@ -14,5 +14,5 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
-exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -n elementary "$@" "" \
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -t elementary "$@" "" \
     exec startelementary

--- a/host-bin/startelementary
+++ b/host-bin/startelementary
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+APPLICATION="${0##*/}"
+
+USAGE="$APPLICATION [options]
+
+Wraps enter-chroot to start a GNOME session.
+By default, it will log into the primary user on the first chroot found.
+
+Options are directly passed to enter-chroot; run enter-chroot to list them."
+
+exec sh -e "`dirname "\`readlink -f "$0"\`"`/enter-chroot" -n elementary "$@" "" \
+    exec startelementary

--- a/targets/elementary
+++ b/targets/elementary
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
+#     if [ "$DISTRO" != 'ubuntu' ]; then
+#         error 99 "unity target is only supported on Ubuntu."
+#     fi
+# fi
+REQUIRES='x11'
+DESCRIPTION='Installs the Elementary desktop environment. (Approx. ~small)'
+HOSTBIN='startelementary'
+CHROOTBIN='crouton-noroot startelementary gnome-session-wrapper'
+. "${TARGETSDIR:="$PWD"}/common"
+
+### Append to prepare.sh:
+# Note that whitespace is important for syntax.
+# See distropkgs method in installer/prepare.sh
+install software-properties-common \
+        -- network-manager
+apt-add-repository -y ppa:elementary-os/os-patches
+apt-add-repository -y ppa:elementary-os/stable
+apt-get update
+apt-get install -y elementary-desktop
+
+TIPS="$TIPS
+You can start Elementary OS via the startelementary host command: sudo startelementary
+"

--- a/targets/elementary
+++ b/targets/elementary
@@ -3,26 +3,51 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
-#     if [ "$DISTRO" != 'ubuntu' ]; then
-#         error 99 "unity target is only supported on Ubuntu."
-#     fi
-# fi
+if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
+    if [ "$DISTRO" != 'ubuntu' ]; then
+        error 99 "elementary target is only supported on Ubuntu."
+    elif ! release -eq precise -o release -eq trusty -o release -eq xenial -o \
+         release -eq yakkety -o release -eq zesty; then
+        error 99 "elementary desktop is not available on this release."
+    fi
+fi
+
 REQUIRES='x11'
-DESCRIPTION='Installs the Elementary desktop environment. (Approx. ~small)'
+DESCRIPTION='Installs the ELEMENTARY desktop environment. (Approx. 700MB)'
 HOSTBIN='startelementary'
 CHROOTBIN='crouton-noroot startelementary gnome-session-wrapper'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-# Note that whitespace is important for syntax.
-# See distropkgs method in installer/prepare.sh
-install software-properties-common \
-        -- network-manager
-apt-add-repository -y ppa:elementary-os/os-patches
-apt-add-repository -y ppa:elementary-os/stable
-apt-get update
-apt-get install -y elementary-desktop
+apt-key adv --keyserver 'keyserver.ubuntu.com' \
+            --recv-keys '4E1F8A59'
+
+# Stable branch only available for LTS releases
+# Expiremental daily branch available for other releases
+if release -eq precise -o release -eq trusty -o release -eq xenial; then
+  cat > '/etc/apt/sources.list.d/elementary-os.list' <<EOF
+deb http://ppa.launchpad.net/elementary-os/os-patches/ubuntu $RELEASE main
+deb-src http://ppa.launchpad.net/elementary-os/os-patches/ubuntu $RELEASE main
+deb http://ppa.launchpad.net/elementary-os/stable/ubuntu $RELEASE main
+deb-src http://ppa.launchpad.net/elementary-os/stable/ubuntu $RELEASE main
+EOF
+else
+  cat > '/etc/apt/sources.list.d/elementary-os.list' <<EOF
+deb http://ppa.launchpad.net/elementary-os/os-patches/ubuntu $RELEASE main
+deb-src http://ppa.launchpad.net/elementary-os/os-patches/ubuntu $RELEASE main
+deb http://ppa.launchpad.net/elementary-os/daily/ubuntu $RELEASE main
+deb-src http://ppa.launchpad.net/elementary-os/daily/ubuntu $RELEASE main
+EOF
+fi
+
+apt-get -y update
+install pantheon elementary-wallpapers elementary-icon-theme \
+        elementary-artwork elementary-default-settings \
+        switchboard switchboard-gnome-control-center switchboard-plug-about \
+        switchboard-plug-display switchboard-plug-pantheon-shell \
+        switchboard-plug-gcc-date switchboard-plug-gcc-users \
+        switchboard-gnome-control-center-override
+
 
 TIPS="$TIPS
 You can start Elementary OS via the startelementary host command: sudo startelementary

--- a/targets/elementary-desktop
+++ b/targets/elementary-desktop
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+REQUIRES='elementary'
+DESCRIPTION='Installs ELEMENTARY along with common applications. (Approx. 1300MB)'
+. "${TARGETSDIR:="$PWD"}/common"
+
+### Append to prepare.sh:
+install elementary-desktop

--- a/test/tests/w8-elementary
+++ b/test/tests/w8-elementary
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if [ -z "$release" ]; then
+    echo "all"
+    exit 0
+fi
+
+target="elementary"
+startcmd="startelementary"
+xte=""
+
+# Run common file
+. "$SCRIPTDIR/test/tests/w0-common"

--- a/test/tests/w8d-elementary-desktop
+++ b/test/tests/w8d-elementary-desktop
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if [ -z "$release" ]; then
+    echo "all"
+    exit 0
+fi
+
+target="elementary-desktop"
+startcmd="startelementary"
+xte=""
+
+# Run common file
+. "$SCRIPTDIR/test/tests/w0-common"

--- a/test/tests/x0-alltargets
+++ b/test/tests/x0-alltargets
@@ -26,7 +26,7 @@ for target in "$SCRIPTDIR/targets/"*; do
     # Some other targets do not require testing in this context,
     # or have their own w* tests
     for blacklist in audio core x11 xiwi xorg \
-                     e17 gnome kde lxde unity xbmc xfce; do
+                     e17 gnome kde lxde unity xbmc xfce elementary; do
         if [ "$target" = "$blacklist" ]; then
             break
         fi


### PR DESCRIPTION
I saw that people were asking for this a while back (#1571), and I've been using the MyDearWatson script and its forks for a while personally, so I decided to put this together.

Test coverage seems to be fine on my 2015 Chromebook Pixel. I'm not sure about other arches, but everything _should_ work. I tried to be thorough, but let me know if any other changes are needed.

A few other things:
- [ ]  Precise is broken. Probably because of the DBUS errors being mentioned lately (#2917)
- [ ]  The system logout button doesn't work on releases xenial+. But `gnome-session-quit --no-prompt` or `gnome-session-quit --logout --force` will close the session. Not sure if this is crouton related.
- [ ] Scaling for HiDPI seems off for xenial+ as well. It happens in xorg and xiwi so I don't if it's related to (#1966). Honestly, I have no idea what the cause is.
- [ ] I'm open to feedback about what all should be included (or removed) in the minimal install. Just wanted to add in the basics.

Merry Christmas guys. :christmas_tree: