### PR TITLE
croutonxinitrc-wrapper: xorg target: kick the display on startup

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -145,6 +145,17 @@ and enabled, and up to date. (download from http://goo.gl/OVQOEt)" 1>&2
     fi
 fi
 
+if [ "$xmethodtype" = "xorg" ]; then
+    # Since Chromium 56.0.2923.0, Chromium tries to switch off the display when
+    # switching VT (crbug.com/655770). For some unclear reason, running xrandr
+    # forces the display to be back on, and this is not needed ever again
+    # when switching VTs.
+    # I'm not clear if the sleep is required, but since this is a race, this
+    # should be a little bit safer.
+    sleep 1
+    xrandr --auto
+fi
+
 # Only run if no error occured before (e.g. cannot connect to extension)
 if [ "$ret" -eq 0 ]; then
     # Shell is the leader of a process group, so signals sent to this process


### PR DESCRIPTION
Since Chromium 56.0.2923.0, Chromium tries to switch off the display when
switching VT (crbug.com/655770). For some unclear reason, running xrandr
forces the display to be back on, and this is not needed ever again
when switching VTs.
I'm not clear if the sleep is required, but since this is a race, this
should be a little bit safer.

Fixes #2923.