### PR TITLE
unity: disable unity on ARM for releases after precise

### DIFF
--- a/targets/unity
+++ b/targets/unity
@@ -6,6 +6,10 @@ if [ "${TARGETNOINSTALL:-c}" = 'c' ]; then
     if [ "$DISTRO" != 'ubuntu' ]; then
         error 99 "unity target is only supported on Ubuntu."
     fi
+
+    if [ "${ARCH#arm}" != "$ARCH" ] && release -gt precise; then
+        error 99 "unity is unsupported on ARM for releases after precise."
+    fi
 fi
 REQUIRES='gtk-extra'
 DESCRIPTION='Installs the Unity desktop environment. (Approx. 700MB)'


### PR DESCRIPTION
This was never supported anyway, so we should make it explicit now
that xenial will be the default release.