### PR TITLE
xfce: Install dummy xfce4-battery-plugin on arm64 < xenial

### DIFF
--- a/targets/xfce
+++ b/targets/xfce
@@ -30,6 +30,10 @@ cat > '/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml' <<EOF
 </channel>
 EOF
 
+if release -lt xenial && [ "$ARCH" = 'arm64' ]; then
+    install_dummy xfce4-battery-plugin
+fi
+
 install xfce4 xfce4-goodies ubuntu=shimmer-themes, \
         -- dictionaries-common hddtemp xorg
 


### PR DESCRIPTION
That package is not provided on trusty/arm64, for some reason.

Fixes #3152.