### PR TITLE
Add dialout group to sync, for use with programming microcontrollers

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -584,8 +584,8 @@ fi
 gfile="$CHROOT/etc/group"
 if [ -f "$gfile" ]; then
     for group in audio:hwaudio cras:audio cdrom chronos-access:crouton \
-                 devbroker-access disk floppy i2c input lp serial tape tty \
-                 usb:plugdev uucp video wayland; do
+                 devbroker-access dialout disk floppy i2c input lp serial \
+                 tape tty usb:plugdev uucp video wayland; do
         hostgroup="${group%:*}"
         chrootgroup="${group#*:}"
         gid="$(awk -F: '$1=="'"$hostgroup"'"{print $3; exit}' '/etc/group')"


### PR DESCRIPTION
This lets the crouton environment work with IDEs like Arduino, NodeMCU, etc. I've only tested on an Asus C100 Flip (ARM.)