### PR TITLE
Add support for opensuse

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -676,11 +676,18 @@ if [ "$NOLOGIN" != 1 ] && grep -q '^root:' "$passwd" 2>/dev/null; then
     fi
 
     # Launch systemd-logind if available and not already running
-    # Whitelisted for saucy and trusty
+    # Whitelisted for saucy, trusty and tumbleweed
     systemd_dir="`fixabslinks '/run/systemd'`"
-    if [ -x "$CHROOT/lib/systemd/systemd-logind" ] && \
+    systemd_logind="/lib/systemd/systemd-logind"
+    # openSUSE has a different systemd folder
+    if [ "$CHROOTRELEASE" = 'tumbleweed' ]; then
+        systemd_logind="/usr/lib/systemd/systemd-logind"
+    fi
+
+    if [ -x "$CHROOT$systemd_logind" ] && \
             [ ! -d "$systemd_dir" ] && \
-            [ "$CHROOTRELEASE" = 'saucy' -o "$CHROOTRELEASE" = 'trusty' ]; then
+            [ "$CHROOTRELEASE" = 'saucy' -o "$CHROOTRELEASE" = 'trusty' \
+            -o "$CHROOTRELEASE" = 'tumbleweed' ]; then
         # Every piece of systemd code ever assumes that this directory exists
         mkdir -p "$systemd_dir"
 
@@ -691,7 +698,7 @@ if [ "$NOLOGIN" != 1 ] && grep -q '^root:' "$passwd" 2>/dev/null; then
                   "$CHROOT/sys/fs/cgroup/systemd"
         fi
         # systemd-logind doesn't fork
-        chrootcmd "/lib/systemd/systemd-logind >/dev/null 2>&1 </dev/null &"
+        chrootcmd "${systemd_logind} >/dev/null 2>&1 </dev/null &"
     fi
 
     chrootcmd "/usr/local/bin/croutonfindnacld >/dev/null 2>&1 </dev/null &"

--- a/installer/opensuse/bootstrap
+++ b/installer/opensuse/bootstrap
@@ -15,6 +15,7 @@ url_tumbleweed_aarch64="http://download.opensuse.org/ports/aarch64/tumbleweed/im
 # Leap
 url_leap_42_2_armv7hl="http://download.opensuse.org/ports/armv7hl/distribution/leap/42.2/appliances/openSUSE-Leap42.2-ARM-JeOS.armv7-rootfs.armv7l.tbz"
 url_leap_42_2_aarch64="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/appliances/openSUSE-Leap42.2-ARM-JeOS.aarch64-rootfs.aarch64.tbz"
+url_leap_42_3_aarch64="http://download.opensuse.org/ports/aarch64/distribution/leap/42.3/appliances/openSUSE-Leap42.3-ARM-JeOS.aarch64-rootfs.aarch64.tbz"
 
 BOOTSTRAP_ARCH="$ARCH"
 BOOTSTRAP_RELEASE="$RELEASE"

--- a/installer/opensuse/bootstrap
+++ b/installer/opensuse/bootstrap
@@ -1,0 +1,45 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a distro-specific bootstrap script, sourced from main.sh, and as such
+# has access to all of the variables set by main.sh, namely $tmp (the temporary
+# directory), $INSTALLERDIR/$DISTRO, $RELEASE, $BOOTSTRAP_RELEASE (if different
+# from $RELEASE), $ARCH, and $MIRROR.
+
+# Tumbleweed
+url_tumbleweed_armv7hl="http://download.opensuse.org/ports/armv7hl/tumbleweed/images/openSUSE-Tumbleweed-ARM-JeOS.armv7hl-rootfs.armv7l-Current.tbz"
+url_tumbleweed_aarch64="http://download.opensuse.org/ports/aarch64/tumbleweed/images/openSUSE-Tumbleweed-ARM-JeOS.aarch64-rootfs.aarch64-Current.tbz"
+
+# Leap
+url_leap_42_2_armv7hl="http://download.opensuse.org/ports/armv7hl/distribution/leap/42.2/appliances/openSUSE-Leap42.2-ARM-JeOS.armv7-rootfs.armv7l.tbz"
+url_leap_42_2_aarch64="http://download.opensuse.org/ports/aarch64/distribution/leap/42.2/appliances/openSUSE-Leap42.2-ARM-JeOS.aarch64-rootfs.aarch64.tbz"
+
+BOOTSTRAP_ARCH="$ARCH"
+BOOTSTRAP_RELEASE="$RELEASE"
+
+# Rename factory to tumbleweed
+if [ "$RELEASE" = "factory" ]; then
+    BOOTSTRAP_RELEASE=tumbleweed
+elif [ "${RELEASE#leap}" != "$RELEASE" ]; then
+     BOOTSTRAP_RELEASE=$(echo "$RELEASE" | tr - _ | tr . _)
+     echo $BOOTSTRAP_RELEASE
+fi
+
+# fix up the good old toolchain/kernel naming conflict
+if [ "$ARCH" = "arm64" ]; then
+     BOOTSTRAP_ARCH=aarch64
+fi
+
+eval "URL=\"\${url_${BOOTSTRAP_RELEASE}_${BOOTSTRAP_ARCH}-}\""
+
+if [ -z "$URL" ]; then
+    echo "Unknown Distribution / Architecture: $BOOTSTRAP_RELEASE $BOOTSTRAP_ARCH" >&2
+    exit 1
+fi
+
+mkdir -p "$tmp/$subdir"
+curl -# -L --connect-timeout 60 --retry 2 "$URL" | tar -jx -C "$tmp/$subdir"
+
+rm -rf "$tmp/$subdir/dev/"*

--- a/installer/opensuse/defaults
+++ b/installer/opensuse/defaults
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is sourced from main.sh to update distro-specific defaults.
+# It must set at least ARCH and MIRROR if not already specified.
+
+if [ -z "$ARCH" ]; then
+    ARCH="$(uname -m)"
+fi
+
+case "$ARCH" in
+arm64 | aarch64) ARCH="arm64";;
+arm*) ARCH="armv7hl";;
+*) error 2 "Invalid architecture '$ARCH'.";;
+esac
+

--- a/installer/opensuse/getrelease.sh
+++ b/installer/opensuse/getrelease.sh
@@ -1,0 +1,50 @@
+#!/bin/sh -e
+# Copyright (c) 2017 The crouton authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+USAGE="${0##*/} -a|-r /path/to/chroot
+
+Detects the release (-r) or arch (-a) of the chroot and prints it on stdout.
+Fails with an error code of 1 if the chroot does not belong to this distro."
+
+if [ "$#" != 2 ] || [ "$1" != '-a' -a "$1" != '-r' ]; then
+    echo "$USAGE" 1>&2
+    exit 2
+fi
+
+sources="${2%/}/etc/os-release"
+if [ ! -s "$sources" ]; then
+    exit 1
+fi
+
+# Create release name from /etc/os-release file
+# sed specialist can make that more elegant...
+rel="$(grep CPE_NAME "$sources" | cut -d ":" -f 4)"
+if [ "$rel" = "opensuse" -o "$rel" = "tumbleweed" ]; then
+    rel=tumbleweed
+elif [ "$rel" = "leap" ]; then
+    ver="$(grep CPE_NAME "$sources" | cut -d ":" -f 5)"
+    rel="$rel-${ver%\"}"
+else
+    exit 1
+fi
+
+# Print the architecture if requested
+# Why use sed if you know cut...
+sources="${2%/}/etc/products.d/openSUSE.prod"
+if [ ! -s "$sources" ]; then
+    exit 1
+fi
+
+if [ "$1" = '-a' ]; then
+    arch="$(grep "<arch>" "$sources" | cut -d '>' -f 2 | cut -d '<' -f 1)"
+    if [ "$arch" = "aarch64" ]; then
+        arch="arm64"
+    fi
+    echo "$arch"
+else
+    echo "$rel"
+fi
+
+exit 0

--- a/installer/opensuse/prepare
+++ b/installer/opensuse/prepare
@@ -1,0 +1,130 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a distro-specific continuation of the prepare.sh script.
+
+PKGEXT='rpm'
+DISTROAKA='opensuse'
+
+
+# install_dist: see install() in prepare.sh for details.
+install_dist() {
+    local pkgs='' params='' asdeps=''
+    while [ "$#" != 0 ]; do
+        if [ "$1" = "--minimal" ]; then
+            params='--no-recommends'
+        elif [ "$1" = "--asdeps" ]; then
+            shift
+            continue
+        else
+            break
+        fi
+        shift
+    done
+    while [ "$#" != 0 ]; do
+        if [ "$1" = '--' ]; then
+            shift
+            break
+        fi
+        pkgs="$pkgs $1"
+        shift
+    done
+    zypper -q install -y $params $pkgs $(list_uninstalled_dist - "$@") || return $?
+}
+
+
+# install_pkg_dist: see install_pkg() in prepare.sh for details.
+install_pkg_dist() {
+    local params=''
+    if [ "$1" = '--minimal' ]; then
+        params='--no-recommends'
+        shift
+    fi
+    if [ "$#" != 0 ]; then
+        zypper -q install -y $params "$@" || return $?
+    fi
+}
+
+
+# install_dummy_dist: see install_dummy() in prepare.sh for details.
+install_dummy_dist() {
+    if [ "$#" = 0 ]; then
+        return
+    fi
+    local pkgname="crouton-$1" pkgprovides="$1" requires=""
+    shift
+    while [ "$#" != 0 ]; do
+        if [ "$1" = '--' ]; then
+            shift
+            break
+        fi
+        pkgprovides="$pkgprovides, $1"
+        shift
+    done
+    local pkgdepends="$1"
+    if [ "$#" != 0 ]; then
+        shift
+        while [ "$#" != 0 ]; do
+            pkgdepends="$pkgdepends, $1"
+            shift
+        done
+    fi
+
+    if [ -n "$pkgdepends" ]; then
+        requires="Requires: ${pkgdepends}"
+    fi
+
+    local tmp="$(mktemp -d crouton.XXXXXX --tmpdir=/tmp)"
+    addtrap "rm -rf '$tmp'"
+    cat > "$tmp/dummy.spec" <<EOF
+Name: $pkgname
+Version: 1.0.0
+Release: 1.0.0
+Group: dummy
+Vendor: dummy
+License: %{vendor}
+Provides: $pkgprovides
+$requires
+Summary: Provides a dummy ${pkgname#*-} for crouton
+BuildRoot: %{_tmppath}/%{name}-%{version}-build
+
+%description
+%{summary}
+
+%files
+EOF
+    rpmbuild --define='_rpmdir "$tmp"' -bb "$tmp/dummy.spec" > "$tmp/build.log"
+    if [ $? != 0 ]; then
+        echo "ERROR: Could not build dummy rpm!"
+	exit 1
+    fi
+    pkg="$(awk '/^wrote:/ { print $2 }' < "$tmp/build.log")"
+    rm "$tmp/build.log"
+    zypper -q install -y --force-resolution "$pkg"
+}
+
+
+# remove_dist: see remove() in prepare.sh for details.
+remove_dist() {
+    zypper -q remove --clean-deps -y "$@"
+}
+
+
+# list_uninstalled_dist: see list_uninstalled() in prepare.sh for details.
+list_uninstalled_dist() {
+    local suffix="$1" pkg
+    shift
+    for pkg in "$@"; do
+        if ! zypper se -i "$pkg" 2>/dev/null | grep -q '^i'; then
+            echo -n "$pkg$suffix "
+        fi
+    done
+}
+
+# enable network ping for all users
+chmod u+s /usr/bin/ping
+
+# add rpmbuild for dummy packages
+install rpmbuild

--- a/installer/opensuse/releases
+++ b/installer/opensuse/releases
@@ -1,2 +1,3 @@
 tumbleweed
 leap-42.2
+leap-42.3

--- a/installer/opensuse/releases
+++ b/installer/opensuse/releases
@@ -1,0 +1,2 @@
+tumbleweed
+leap-42.2

--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -199,7 +199,7 @@ compile() {
     fi
     shift 2
     echo "Installing dependencies for $out..." 1>&2
-    local pkgs="gcc libc6-dev $*"
+    local pkgs="gcc opensuse=glibc-devel,libc6-dev $*"
     install --minimal --asdeps $pkgs </dev/null
     echo "Compiling $out..." 1>&2
     local tmp="`mktemp crouton.XXXXXX --tmpdir=/tmp`"

--- a/targets/audio
+++ b/targets/audio
@@ -85,8 +85,8 @@ build_cras() {
     install --minimal alsa-utils \
         libasound2$pkgsuffix libspeexdsp1$pkgsuffix
 
-    install --minimal --asdeps gcc $pkgdepextra libc6-dev$pkgsuffix \
-        pkg-config libspeexdsp-dev$pkgsuffix
+    install --minimal --asdeps gcc $pkgdepextra opensuse=glibc-devel,libc6-dev$pkgsuffix \
+        pkg-config opensuse=speexdsp-devel,libspeexdsp-dev$pkgsuffix
 
     # precise does not allow libasound2-dev and libasound2-dev:i386 to be
     # installed simultaneously
@@ -99,6 +99,13 @@ build_cras() {
             ln -sfT libasound.so.2 "$libasoundso"
         fi
         ALSALIBDIR="/usr/lib$archextrapath/alsa-lib"
+    elif [ "$DISTROAKA" = "opensuse" ]; then
+        install --minimal --asdeps alsa-devel
+        if [ "$ARCH" = "arm64" -o "$ARCH" = "x86_64"]; then
+            ALSALIBDIR="/usr/lib64/alsa-lib"
+        else
+            ALSALIBDIR="/usr/lib/alsa-lib"
+        fi
     else
         install --minimal --asdeps libasound2-dev$pkgsuffix
         ALSALIBDIR="`PKG_CONFIG_PATH="$pkgconfigpath" \

--- a/targets/chromium
+++ b/targets/chromium
@@ -5,7 +5,7 @@
 if [ "${TARGETNOINSTALL:-c}" = 'c' ] &&
         [ "$DISTRO" = 'debian' -o "$DISTRO" = 'kali' ] &&
         [ "${ARCH#arm}" != "$ARCH" ]; then
-    error 99 "chromium target is not supported on Debian/ARM."
+    error 99 "chromium target is not supported on $DISTRO on ARM."
 fi
 REQUIRES='x11'
 DESCRIPTION="Chromium browser. Uses the distro's version, which may be old."

--- a/targets/chromium
+++ b/targets/chromium
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 if [ "${TARGETNOINSTALL:-c}" = 'c' ] &&
-        [ "$DISTRO" = 'debian' -o "$DISTRO" = 'kali' ] &&
+        [ "$DISTRO" = 'debian' -o "$DISTRO" = 'kali' -o "$DISTROAKA" = 'opensuse' ] &&
         [ "${ARCH#arm}" != "$ARCH" ]; then
     error 99 "chromium target is not supported on $DISTRO on ARM."
 fi

--- a/targets/cli-extra
+++ b/targets/cli-extra
@@ -9,7 +9,7 @@ CHROOTBIN='croutonpowerd'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-install dbus openssh-client kbd
+install opensuse=dbus-1,dbus opensuse=openssh,openssh-client kbd
 
 TIPS="$TIPS
 You can start a shell in a new VT via the startcli host command: sudo startcli

--- a/targets/core
+++ b/targets/core
@@ -110,7 +110,7 @@ fi
 fixkeyboardmode
 
 # Install critical packages
-install --minimal sudo wget ca-certificates apt-transport-https
+install --minimal sudo wget ca-certificates opensuse=,apt-transport-https
 
 # Generate and set default locale
 if [ ! -f '/etc/default/locale' ] && hash locale-gen 2>/dev/null; then

--- a/targets/extension
+++ b/targets/extension
@@ -19,7 +19,7 @@ fi
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-install x11-utils xsel
+install opensuse=xprop,x11-utils xsel
 
 compile websocket ''
 

--- a/targets/gnome
+++ b/targets/gnome
@@ -16,9 +16,9 @@ fi
 
 ### Append to prepare.sh:
 install --minimal evolution-data-server gnome-control-center \
-        gnome-screensaver gnome-session $legacy_session_package \
-        gnome-shell gnome-themes-standard gvfs-backends nautilus \
-        unzip gtk2-engines-pixbuf pulseaudio
+        opensuse=,gnome-screensaver gnome-session $legacy_session_package \
+        gnome-shell opensuse=gnome-themes,gnome-themes-standard gvfs-backends \
+        nautilus unzip opensuse=gtk2-engines,gtk2-engines-pixbuf pulseaudio
 
 TIPS="$TIPS
 You can start GNOME via the startgnome host command: sudo startgnome

--- a/targets/gtk-extra
+++ b/targets/gtk-extra
@@ -8,17 +8,19 @@ DESCRIPTION='GTK-based tools including gdebi, gksu, and a simple browser.'
 
 ### Append to prepare.sh:
 install_dummy network-manager network-manager-gnome
-install gdebi gksu
+install opensuse=,gdebi opensuse=libgnomesu,gksu
 
-for BROWSER in netsurf-gtk dillo hv3 ""; do
-    test -n "$BROWSER"
-    if install "$BROWSER"; then
-        bin="/usr/bin/$BROWSER"
-        for link in x-www-browser gnome-www-browser; do
-            if ! update-alternatives --query "$link" | grep -q "$bin"; then
-                update-alternatives --install "/usr/bin/$link" "$link" "$bin" 10
-            fi
-        done
-        break
-    fi
-done
+if [ "$DISTROAKA" != "opensuse" ]; then
+    for BROWSER in netsurf-gtk dillo hv3 ""; do
+        test -n "$BROWSER"
+        if install "$BROWSER"; then
+            bin="/usr/bin/$BROWSER"
+            for link in x-www-browser gnome-www-browser; do
+                if ! update-alternatives --query "$link" | grep -q "$bin"; then
+                    update-alternatives --install "/usr/bin/$link" "$link" "$bin" 10
+                fi
+            done
+            break
+        fi
+    done
+fi

--- a/targets/post-common
+++ b/targets/post-common
@@ -34,8 +34,15 @@ if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
     apt-get clean
 fi
 
+groups='audio,input,video,wayland,plugdev,crouton'
+
 # Add the primary user
-groups='audio,input,video,wayland,sudo,plugdev,crouton'
+if [ "${DISTROAKA:-"$DISTRO"}" = 'opensuse' ]; then
+    groups=$groups',root'
+else
+    groups=$groups',sudo'
+fi
+
 if ! grep -q ':1000:' /etc/passwd; then
     while ! echo "$username" | grep -q '^[a-z][-a-z0-9_]*$'; do
         if [ -n "$username" ]; then

--- a/targets/x11-common
+++ b/targets/x11-common
@@ -23,16 +23,16 @@ if [ -n "$offset" ]; then
 fi
 
 # Install utilities and links for powerd-poking daemon
-compile xi2event '-lX11 -lXi' libx11-dev libxi-dev
-install --minimal dbus xdg-utils
+compile xi2event '-lX11 -lXi' opensuse=libX11-devel,libx11-dev opensuse=libXi-devel,libxi-dev
+install --minimal opensuse=dbus-1,dbus xdg-utils
 ln -sf croutonpowerd /usr/local/bin/gnome-screensaver-command
 ln -sf croutonpowerd /usr/local/bin/xscreensaver-command
 
 # Install nicer cursors
-install --minimal dmz-cursor-theme
+install --minimal opensuse=dmz-icon-theme-cursors,dmz-cursor-theme
 
 # Install bsdmainutils, xbindkeys and xautomation for shortcuts
-install --minimal bsdmainutils xbindkeys xautomation
+install --minimal opensuse=,bsdmainutils xbindkeys xautomation
 
 # We need chvt on freon systems
 if [ -f "/sys/class/tty/tty0/active" ]; then

--- a/targets/xfce
+++ b/targets/xfce
@@ -34,8 +34,8 @@ if release -lt xenial && [ "$ARCH" = 'arm64' ]; then
     install_dummy xfce4-battery-plugin
 fi
 
-install xfce4 xfce4-goodies ubuntu=shimmer-themes, \
-        -- dictionaries-common hddtemp xorg
+install opensuse=pattern:xfce_basis,xfce4 opensuse=,xfce4-goodies ubuntu=shimmer-themes, \
+        -- opensuse=,dictionaries-common hddtemp opensuse=xorg-x11-server,xorg
 
 TIPS="$TIPS
 You can start Xfce via the startxfce4 host command: sudo startxfce4

--- a/targets/xiwi
+++ b/targets/xiwi
@@ -28,7 +28,8 @@ if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
     apt-mark unhold xserver-xorg-video-dummy$ltspackages || true 2>/dev/null
 fi
 
-install xorg xserver-xorg-video-dummy$ltspackages
+install opensuse=xinit, opensuse=xorg-x11-server,xorg \
+    opensuse=xf86-video-dummy,xserver-xorg-video-dummy$ltspackages
 install --minimal i3
 
 # Remove some unsupported options on old versions of i3
@@ -38,7 +39,8 @@ fi
 
 # Compile croutonfbserver
 compile fbserver '-lX11 -lXfixes -lXdamage -lXext -lXtst' \
-    libx11-dev libxfixes-dev libxdamage-dev libxext-dev libxtst-dev
+    opensuse=libX11-devel,libx11-dev opensuse=libXfixes-devel,libxfixes-dev opensuse=libXdamage-devel,libxdamage-dev \
+    opensuse=libXext-devel,libxext-dev opensuse=libXtst-devel,libxtst-dev
 compile findnacld ''
 
 ln -sf /etc/crouton/xorg-dummy.conf /etc/X11/
@@ -60,8 +62,8 @@ fi
 wget $superinsecure -O "$DUMMYBUILDTMP/dummy.tar.gz" \
      "$urlbase/xf86-video-dummy-0.3.8.tar.gz"
 
-install --minimal --asdeps patch gcc libc-dev pkg-config \
-    xserver-xorg-dev$ltspackages x11proto-xf86dga-dev
+install --minimal --asdeps patch gcc opensuse=glibc-devel,libc-dev pkg-config \
+    opensuse=xorg-x11-server-sdk,xserver-xorg-dev$ltspackages opensuse=xf86dgaproto-devel,x11proto-xf86dga-dev
 
 (
     cd "$DUMMYBUILDTMP"
@@ -398,9 +400,15 @@ EOF
     echo "Installing Xorg dummy driver..." 1>&2
 
     DRIVERDIR="/usr/lib/xorg/modules/drivers"
+    if [ "${DISTROAKA:-"$DISTRO"}" = 'opensuse' ]; then
+        if [ "${ARCH}" = "arm64" -o "${ARCH}" = "x86_64" ]; then
+            DRIVERDIR="/usr/lib64/xorg/modules/drivers"
+        fi
+    fi
     mkdir -p "$DRIVERDIR/"
     /usr/bin/install -s dummy_drv.so "$DRIVERDIR/"
 ) # End compilation subshell
+
 
 if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
     # Hold xserver-xorg-video-dummy to make sure the driver does not get erased

--- a/targets/xorg
+++ b/targets/xorg
@@ -68,7 +68,7 @@ if [ "${ARCH#arm}" = "$ARCH" ]; then
 fi
 
 # Catalog relevant and irrelevant video drivers
-fbdev="xserver-xorg-video-fbdev$backport"
+fbdev="opensuse=xf86-video-fbdev,xserver-xorg-video-fbdev$backport"
 
 if release -lt sid -lt kali-rolling -lt vivid; then
     modesetting="xserver-xorg-video-modesetting$backport"
@@ -97,7 +97,7 @@ fi
 
 # On Freon, we need crazy xorg hacks
 if [ -n "$freon" ]; then
-    compile freon '-ldl -ldrm -I/usr/include/libdrm' so libdrm-dev
+    compile freon '-ldl -ldrm -I/usr/include/libdrm' so opensuse=libdrm-devel,libdrm-dev
 fi
 
 # Pin precise's version of mesa if necessary
@@ -183,6 +183,8 @@ fi
 
 if release -lt stretch -lt kali-rolling -lt yakkety; then
     vmmouse='xserver-xorg-input-vmmouse'
+elif [ "$DISTROAKA" = "opensuse" ]; then
+    vmmouse='xorg-x11-driver-input'
 else
     # xserver-xorg-input-vmmouse is obsolete
     vmmouse=''
@@ -194,11 +196,12 @@ if [ -z "$inteldriver" -a -n "$backport" ] && release -eq precise; then
     # so replace it with something not broken
     install_dummy xorg -- xserver-xorg$backport libgl1-mesa-glx$backport \
         libgl1-mesa-dri$backport libglu1-mesa xfonts-base x11-apps \
-        x11-session-utils x11-utils x11-xfs-utils x11-xkb-utils \
+        x11-session-utils opensuse=xprop,x11-utils x11-xfs-utils x11-xkb-utils \
         x11-xserver-utils xauth xinit xfonts-utils xkb-data xorg-docs-core \
         xterm x11-common xinput
 else
-    install xorg $installvideodrivers -- xserver-xorg-video-all$backport \
+    install opensuse=xorg-x11-server,xorg $installvideodrivers \
+        -- opensuse=xorg-x11-driver-video,xserver-xorg-video-all$backport \
         $vmmouse
 fi
 


### PR DESCRIPTION
Know issues:

1. adhd compilation with gcc7 is broken. Patch to fix this is submitted. As a workaround we would need to pass --Wno-error=int-in-bool-context (this holds for tumbleweed, leap 42.2 should work without a problem).
2. no audio working, need investigation

normal instalation should work without problems:
sudo sh crouton -r tumbleweed -n test -t xiwi,xfce,keyboard,cli-extra
sudo sh crouton -r leap-42.2 -n test -t xiwi,xfce,keyboard,cli-extra