### PR TITLE
Added new debian testing branch buster

### DIFF
--- a/installer/debian/releases
+++ b/installer/debian/releases
@@ -7,4 +7,5 @@ squeeze!
 wheezy
 jessie
 stretch
+buster
 sid


### PR DESCRIPTION
Debian stretch became stable branch on 2017-06-17, and the new testing branch code-name is buster [1].

[1] https://www.debian.org/releases/buster/