### PR TITLE
Use updated dbus method calls

### DIFF
--- a/src/freon.c
+++ b/src/freon.c
@@ -25,11 +25,11 @@
 
 #define LOCK_FILE_DIR "/tmp/crouton-lock"
 #define DISPLAY_LOCK_FILE LOCK_FILE_DIR "/display"
-#define FREON_DBUS_METHOD_CALL(function) \
+#define LIBCROSSERVICE_METHOD_CALL(function) \
     system("host-dbus dbus-send --system --dest=org.chromium.LibCrosService " \
            "--type=method_call --print-reply /org/chromium/LibCrosService " \
            "org.chromium.LibCrosServiceInterface." #function)
-#define FREON_DBUS_METHOD_CALL_NEW(function) \
+#define DISPLAYSERVICE_METHOD_CALL(function) \
     system("host-dbus dbus-send --system --dest=org.chromium.DisplayService " \
            "--type=method_call --print-reply /org/chromium/DisplayService " \
            "org.chromium.DisplayServiceInterface." #function)
@@ -166,9 +166,9 @@ int ioctl(int fd, unsigned long int request, ...) {
             (request == VT_ACTIVATE && (uintptr_t)data == 0)) {
             if (lockfd != -1) {
                 TRACE("Telling Chromium OS to regain control\n");
-                ret = FREON_DBUS_METHOD_CALL(TakeDisplayOwnership);
+                ret = LIBCROSSERVICE_METHOD_CALL(TakeDisplayOwnership);
                 if (WEXITSTATUS(ret) == 1) {
-                    ret = FREON_DBUS_METHOD_CALL_NEW(TakeOwnership);
+                    ret = DISPLAYSERVICE_METHOD_CALL(TakeOwnership);
                 }
                 if (set_display_lock(0) < 0) {
                     ERROR("Failed to release display lock\n");
@@ -178,9 +178,9 @@ int ioctl(int fd, unsigned long int request, ...) {
                    (request == VT_ACTIVATE && (uintptr_t)data == 7)) {
             if (set_display_lock(getpid()) == 0) {
                 TRACE("Telling Chromium OS to drop control\n");
-                ret = FREON_DBUS_METHOD_CALL(ReleaseDisplayOwnership);
+                ret = LIBCROSSERVICE_METHOD_CALL(ReleaseDisplayOwnership);
                 if (WEXITSTATUS(ret) == 1) {
-                    ret = FREON_DBUS_METHOD_CALL_NEW(ReleaseOwnership);
+                    ret = DISPLAYSERVICE_METHOD_CALL(ReleaseOwnership);
                 }
             } else {
                 ERROR("Unable to claim display lock\n");

--- a/src/freon.c
+++ b/src/freon.c
@@ -29,6 +29,10 @@
     system("host-dbus dbus-send --system --dest=org.chromium.LibCrosService " \
            "--type=method_call --print-reply /org/chromium/LibCrosService " \
            "org.chromium.LibCrosServiceInterface." #function)
+#define FREON_DBUS_METHOD_CALL_NEW(function) \
+    system("host-dbus dbus-send --system --dest=org.chromium.DisplayService " \
+           "--type=method_call --print-reply /org/chromium/DisplayService " \
+           "org.chromium.DisplayServiceInterface." #function)
 
 #define TRACE(...) /* fprintf(stderr, __VA_ARGS__) */
 #define ERROR(...) fprintf(stderr, __VA_ARGS__)
@@ -163,6 +167,9 @@ int ioctl(int fd, unsigned long int request, ...) {
             if (lockfd != -1) {
                 TRACE("Telling Chromium OS to regain control\n");
                 ret = FREON_DBUS_METHOD_CALL(TakeDisplayOwnership);
+                if (WEXITSTATUS(ret) == 1) {
+                    ret = FREON_DBUS_METHOD_CALL_NEW(TakeOwnership);
+                }
                 if (set_display_lock(0) < 0) {
                     ERROR("Failed to release display lock\n");
                 }
@@ -172,6 +179,9 @@ int ioctl(int fd, unsigned long int request, ...) {
             if (set_display_lock(getpid()) == 0) {
                 TRACE("Telling Chromium OS to drop control\n");
                 ret = FREON_DBUS_METHOD_CALL(ReleaseDisplayOwnership);
+                if (WEXITSTATUS(ret) == 1) {
+                    ret = FREON_DBUS_METHOD_CALL_NEW(ReleaseOwnership);
+                }
             } else {
                 ERROR("Unable to claim display lock\n");
                 ret = -1;


### PR DESCRIPTION
Fixes #3375

Due to dbus interface changes in Chrome OS, if one dbus method call fails, then run the other one right after.