### PR TITLE
Fix xserver-xorg-legacy issue with dummy package

### DIFF
--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -86,9 +86,11 @@ Architecture: all
 Maintainer: crouton
 Installed-Size: 0
 Provides: $pkgprovides
+Conflicts: $pkgprovides
+Replaces: $pkgprovides
 Depends: $pkgdepends
 Section: misc
-Priority: optional
+Priority: Required
 Description: Provides a dummy ${pkgname#*-} for crouton
 EOF
     touch "$tmp/md5sums"

--- a/targets/x11-common
+++ b/targets/x11-common
@@ -7,6 +7,10 @@
 # forms of X11.
 
 ### Append to prepare.sh:
+
+# Create dummy xserver-xorg-legacy
+install_dummy xserver-xorg-legacy
+
 # Store and apply the X11 method
 ln -sfT '/etc/crouton/xserverrc' '/etc/X11/xinit/xserverrc'
 echo "$XMETHOD" > '/etc/crouton/xmethod'


### PR DESCRIPTION
not sure how or why all my synced changes are showing up in this pull request...  I'm a beginner with git...

This pull request makes the suggested change to the x11-common target, but it's not working properly for me.  It seems to create a dummy package named `crouton-xserver-xorg-legacy`, which doesn't block the installation of the real `xserver-xorg-legacy` package which breaks x.

@dnschneid do you have any ideas?  Have i just uncovered an unrelated issue?