### PR TITLE
Add confirmation on xiwi tab close for #3222

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,7 +19,7 @@ David Schneider
 Dennis Lockhart
 dimonf
 dumpweed
-eyqs
+Eugene Y. Q. Shen
 George Shank
 icecream95
 Igor Bukanov

--- a/host-ext/crouton/window.js
+++ b/host-ext/crouton/window.js
@@ -301,6 +301,9 @@ document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('visibilitychange', handleFocusBlur);
     chrome.runtime.onMessage.addListener(handleRequest);
 
+    // Display confirmation message before closing the tab
+    window.onbeforeunload = function () { return true; };
+
     infodiv_ = document.getElementById('info');
     statusdiv_ = document.getElementById('status');
     warningdiv_ = document.getElementById('warning');


### PR DESCRIPTION
This addresses #3222 by providing a "Do you want to leave this site?" dialog when the user closes a crouton extension tab. For some reason, this dialog does not show up if you immediately close the tab as soon as it opens, no matter where the onbeforeunload line is placed. This shouldn't be too much of an issue though, because there's no chance of losing any unsaved work if you immediately close the tab like that.