### PR TITLE
Update bootstrap extractor

### DIFF
--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -73,6 +73,6 @@ fi
 # Grab the release and drop it into the subdirectory
 echo 'Downloading bootstrap files...' 1>&2
 PATH="$newpath" DEBOOTSTRAP_DIR="$tmp" $FAKEROOT \
-    "$tmp/debootstrap" --foreign --arch="$ARCH" \
+    "$tmp/debootstrap" --foreign --extractor='ar' --arch="$ARCH" \
     "$RELEASE" "$tmp/$subdir" "$MIRROR" 1>&2
 


### PR DESCRIPTION
Add extractor override so that the bootstrap will always use 'ar'.
Resolves: New chroot installation(s) failing on Acer C7 (parrot) - for me. #3413