### PR TITLE
Kodi - Open ports to allow smb/samba browsing

### DIFF
--- a/host-bin/startkodi
+++ b/host-bin/startkodi
@@ -14,5 +14,10 @@ By default, it will log into the primary user on the first chroot found.
 
 Options are directly passed to enter-chroot; run enter-chroot to list them."
 
+# Forward ports needed to browse smb shares
+if test -n "$(ip -4 -o addr show dev wlan0| awk '{split($4,a,"/");print a[1]}')"; then
+	iptables -I INPUT 1 -p udp --source $(ip -4 -o addr show dev wlan0| awk '{split($4,a,"/");print a[1]}')/255.255.255.0 --dport 1025:65535 -j ACCEPT
+fi
+
 exec sh -e "`dirname "\`readlink -f -- "$0"\`"`/enter-chroot" -t kodi "$@" "" \
     exec croutonpowerd -i xinit /usr/bin/kodi --standalone


### PR DESCRIPTION
browsing smb/samba shares requires having ports 1025 - 65535 open. 
Source: [https://github.com/dnschneid/crouton/wiki/How-to-mount-network-shares-on-Chromebook-(sshfs,-cifs,-nfs-etc)](url)

this patch grabs the ip address from wlan0 and opens the ports when the source ip is within the local subnet.  if wlan0 has no ip, it does not modify iptables.

I'm not sure how many ChromeOS devices have an eth0, or any other interfaces that should be accounted for. or perhaps there is a better way to accomplish the same thing.

iptables gets reset on reboots, so it's probably not a big deal that the rule doesn't get cleared.  however, i would love to clear the port forward when kodi closes, or the chroot exits.  do you have any ideas for this @dnschneid ?



