### PR TITLE
Use Downloads folder of the user who launched the chroot

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -456,7 +456,9 @@ fi
 # Bind-mount the stuff in $CHROOT/etc/crouton/shares, unless NOLOGIN is set
 if [ -z "$NOLOGIN" -a -f "$shares" ]; then
     if [ "$activeuser" != "Default" ]; then
-        localdownloads="$(jq -r '.profile.info_cache | to_entries[] | select(.value.user_name == "'$activeuser'") | "/home/chronos/\(.key)/Downloads"' '/home/chronos/Local State')"
+        localdownloads="$(jq -r '.profile.info_cache | to_entries[]
+          | select(.value.user_name == "'$activeuser'")
+          | "/home/chronos/\(.key)/Downloads"' '/home/chronos/Local State')"
     fi
     if [ -z "$localdownloads" ]; then
         localdownloads='/home/chronos/user/Downloads'

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -338,15 +338,6 @@ tmpfsmount() {
     mount -i -t tmpfs -o "rw${2:+,}$2" tmpfs "$target"
 }
 
-# Determines currently-logged in user
-getactiveuser() {
-    local activeuser="Default"
-    if [ -x "/usr/bin/jq" ]; then
-        activeuser="$(jq -r .LastActiveUser '/home/chronos/Local State')"
-    fi
-    echo $activeuser
-}
-
 # If /var/run isn't mounted, we know the chroot hasn't been started yet.
 if mountpoint -q "`fixabslinks '/var/run'`"; then
     firstrun=''
@@ -446,16 +437,13 @@ downloads ~/Downloads
 EOF
 fi
 
-activeuser=$(getactiveuser)
-if [ -n "$firstrun" ]; then
-    # Store the active user for possible use in other scripts, etc.
-    activeuserfile="$(fixabslinks '/etc/crouton/user')"
-    echo "$activeuser" > $activeuserfile
-fi
-
 # Bind-mount the stuff in $CHROOT/etc/crouton/shares, unless NOLOGIN is set
 if [ -z "$NOLOGIN" -a -f "$shares" ]; then
-    if [ "$activeuser" != "Default" ]; then
+    activeuser=''
+    if [ -x "/usr/bin/jq" ]; then
+        activeuser="$(jq -r .LastActiveUser '/home/chronos/Local State')"
+    fi
+    if [ -n "$activeuser" ]; then
         localdownloads="$(jq -r '.profile.info_cache | to_entries[]
           | select(.value.user_name == "'$activeuser'")
           | "/home/chronos/\(.key)/Downloads"' '/home/chronos/Local State')"

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -338,6 +338,15 @@ tmpfsmount() {
     mount -i -t tmpfs -o "rw${2:+,}$2" tmpfs "$target"
 }
 
+# Determines currently-logged in user
+getactiveuser() {
+    local activeuser="Default"
+    if [ -x "/usr/bin/jq" ]; then
+        activeuser=$(jq -r .LastActiveUser /home/chronos/Local\ State)
+    fi
+    echo $activeuser
+}
+
 # If /var/run isn't mounted, we know the chroot hasn't been started yet.
 if mountpoint -q "`fixabslinks '/var/run'`"; then
     firstrun=''
@@ -436,9 +445,21 @@ elif [ ! -f "$shares" ]; then
 downloads ~/Downloads
 EOF
 fi
+
+activeuser=$(getactiveuser)
+if [ -n "$firstrun" ]; then
+    # Store the active user for possible use in other scripts, etc.
+    activeuserfile="$(fixabslinks '/etc/crouton/user')"
+    echo $activeuser > $activeuserfile
+fi
+
 # Bind-mount the stuff in $CHROOT/etc/crouton/shares, unless NOLOGIN is set
 if [ -z "$NOLOGIN" -a -f "$shares" ]; then
-    localdownloads='/home/chronos/user/Downloads'
+    if [ "$activeuser" != "Default" ]; then
+        localdownloads=$(jq -r ".profile.info_cache | to_entries[] | select(.value.user_name == \"$activeuser\") | \"/home/chronos/\(.key)/Downloads\"" /home/chronos/Local\ State)
+    else
+        localdownloads='/home/chronos/user/Downloads'
+    fi
     if [ ! -d "$localdownloads" ]; then
         localdownloads=''
     fi

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -457,7 +457,8 @@ fi
 if [ -z "$NOLOGIN" -a -f "$shares" ]; then
     if [ "$activeuser" != "Default" ]; then
         localdownloads=$(jq -r ".profile.info_cache | to_entries[] | select(.value.user_name == \"$activeuser\") | \"/home/chronos/\(.key)/Downloads\"" /home/chronos/Local\ State)
-    else
+    fi
+    if [ -z "$localdownloads" ]; then
         localdownloads='/home/chronos/user/Downloads'
     fi
     if [ ! -d "$localdownloads" ]; then

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -342,7 +342,7 @@ tmpfsmount() {
 getactiveuser() {
     local activeuser="Default"
     if [ -x "/usr/bin/jq" ]; then
-        activeuser=$(jq -r .LastActiveUser /home/chronos/Local\ State)
+        activeuser="$(jq -r .LastActiveUser '/home/chronos/Local State')"
     fi
     echo $activeuser
 }
@@ -450,13 +450,13 @@ activeuser=$(getactiveuser)
 if [ -n "$firstrun" ]; then
     # Store the active user for possible use in other scripts, etc.
     activeuserfile="$(fixabslinks '/etc/crouton/user')"
-    echo $activeuser > $activeuserfile
+    echo "$activeuser" > $activeuserfile
 fi
 
 # Bind-mount the stuff in $CHROOT/etc/crouton/shares, unless NOLOGIN is set
 if [ -z "$NOLOGIN" -a -f "$shares" ]; then
     if [ "$activeuser" != "Default" ]; then
-        localdownloads=$(jq -r ".profile.info_cache | to_entries[] | select(.value.user_name == \"$activeuser\") | \"/home/chronos/\(.key)/Downloads\"" /home/chronos/Local\ State)
+        localdownloads="$(jq -r '.profile.info_cache | to_entries[] | select(.value.user_name == "'$activeuser'") | "/home/chronos/\(.key)/Downloads"' '/home/chronos/Local State')"
     fi
     if [ -z "$localdownloads" ]; then
         localdownloads='/home/chronos/user/Downloads'


### PR DESCRIPTION
For multiple logins, this uses the `LastActiveUser` in `/home/chronos/Local State` to determine which ~/Downloads folder should be mapped in the chroot, i.e. that of the user who started the chroot.

Additionally, this creates `/etc/crouton/user` containing the email address of the ~/Downloads "owner".

See also issue #1410 