### PR TITLE
Fix horizontal scroll direction for xiwi

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -122,6 +122,8 @@ fi
 
 # Crouton-in-a-tab: Start fbserver and launch display
 if [ "$xmethodtype" = 'xiwi' ]; then
+    # Fix horizontal scroll direction
+    xmodmap -e "pointer = 1 2 3 4 5 7 6"
     # The extension sends evdev key codes: fix the keyboard mapping rules
     setxkbmap -rules evdev
     # Reapply xkb map: This fixes autorepeat mask in "xset q"


### PR DESCRIPTION
xiwi apps scroll horizontally in the opposite direction as ChromeOS. This just reverses the direction via xmodmap and makes scrolling consistent across xiwi and ChromeOS.

Tested with Australian/traditional settings, KDE/XFCE desktops, and separate xiwi windows.

See also #3519 