### PR TITLE
Update xinitrc wrapper to set trackpad sensitivity for the Pixelbook

### DIFF
--- a/chroot-bin/croutonxinitrc-wrapper
+++ b/chroot-bin/croutonxinitrc-wrapper
@@ -109,7 +109,7 @@ if [ "$xmethodtype" != "xiwi" ]; then
         fi
         # Other special cases
         case "`awk -F= '/_RELEASE_BOARD=/{print $2}' '/var/host/lsb-release'`" in
-            butterfly*|falco*)
+            butterfly*|eve*|falco*)
                 SYNCLIENT="FingerLow=1 FingerHigh=5 $SYNCLIENT";;
             parrot*|peppy*|wolf*)
                 SYNCLIENT="FingerLow=5 FingerHigh=10 $SYNCLIENT";;


### PR DESCRIPTION
Fix suggested here: https://github.com/dnschneid/crouton/issues/3487#issuecomment-341944753

Tested on my Pixelbook and it resolved the issue.

Pixelbook board name is "eve", as reported here:

https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices

and verified on my Pixelbook in `/var/host/lsb-release`
