### PR TITLE
Remove gksu from gtk-extra target for debian buster and kali-rolling

### DIFF
--- a/targets/gtk-extra
+++ b/targets/gtk-extra
@@ -3,12 +3,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 REQUIRES='x11'
-DESCRIPTION='GTK-based tools including gdebi, gksu, and a simple browser.'
+DESCRIPTION='GTK-based tools including gdebi and a simple browser.'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
 install_dummy network-manager network-manager-gnome
-install gdebi gksu
+install gdebi
+if release -lt buster -lt kali-rolling; then
+  install gksu
+fi
 
 for BROWSER in netsurf-gtk dillo hv3 ""; do
     test -n "$BROWSER"

--- a/targets/gtk-extra
+++ b/targets/gtk-extra
@@ -9,7 +9,7 @@ DESCRIPTION='GTK-based tools including gdebi and a simple browser.'
 ### Append to prepare.sh:
 install_dummy network-manager network-manager-gnome
 install gdebi
-if release -lt buster -lt kali-rolling; then
+if release -lt buster -lt kali-rolling -lt artful; then
   install gksu
 fi
 


### PR DESCRIPTION
Per debian's bug, they've removed gksu (but patched gdebi to use policy kit):
https://bugs.debian.org/867236

Should fix [3623](https://github.com/dnschneid/crouton/issues/3623)/[3621](https://github.com/dnschneid/crouton/issues/3621) and buster, which has the same issue atm. 