### PR TITLE
ubuntu: Deprecate zesty

### DIFF
--- a/installer/ubuntu/releases
+++ b/installer/ubuntu/releases
@@ -23,6 +23,6 @@ vivid!
 wily!
 xenial
 yakkety!
-zesty*|test
+zesty!
 artful*|test
 bionic*|test


### PR DESCRIPTION
EOL on January 13, 2018.