### PR TITLE
For clueless non-gamers like me, wikify EXP

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ some suggestions:
   * Discovered a bug lurking within the scripts, or a papercut that bothers you
     just enough to make you want to actually do something about it? You guessed
     it: fork crouton, fix everything, and create a pull request.
-  * Are most bugs too high-level for you to defeat? Grind up some EXP by using
+  * Are most bugs too high-level for you to defeat? Grind up some
+    [EXP](https://en.wikipedia.org/wiki/Experience_point) by using
     your fork to eat [pie](https://github.com/dnschneid/crouton/labels/pie).
 
 


### PR DESCRIPTION
I.e. just change README.md to add a link to the Wikipedia article for https://en.wikipedia.org/wiki/Experience_point

Note: the term "eat pie" is cute but also confusing. If there was a "description" on the "pie" label, that would help. I guess I don't have the rights to edit labels for this repo.  cf. https://help.github.com/articles/creating-a-label/
