### PR TITLE
bootstrap: Use debootstrap 1.0.101

### DIFF
--- a/installer/ubuntu/bootstrap
+++ b/installer/ubuntu/bootstrap
@@ -9,8 +9,7 @@
 # from $RELEASE), $ARCH, and $MIRROR.
 
 # Grab a known good release of debootstrap
-# TODO(#3713): Figure out why >= 1.0.92~bpo9+1 is broken
-debootstrap_version="1.0.92~bpo9+1"
+debootstrap_version="1.0.101"
 
 echo "Downloading debootstrap ${debootstrap_version}..." 1>&2
 if [ "${debootstrap_version}" = "HEAD" ]; then
@@ -29,16 +28,14 @@ fi
 # Patch debootstrap so that it retries downloading packages
 echo 'Patching debootstrap...' 1>&2
 if awk '
-    t == 3 && /warning RETRY/ { print "sleep 1"; t=4 }
-    t == 2 && /-z \"\$checksum\"/ { sub(/\$checksum/, "$checksum$failed"); t=3 }
-    t == 1 { if (/if \[/) { sub(/if \[/, "elif ["); t=2 } else { exit 1 } }
-    /if ! just_get \"\$from\" \"\$dest2\"; then continue 2; fi/ {
-        sub(/if !/, "failed=; if !")
-        sub(/continue 2; fi/, "failed=y")
-        t=1
-    }
+    t == 4 && /-z \"\$checksum\"/ { sub(/\$checksum/, "$checksum$failed"); t=5 }
+    t == 3 && /\"\$checksum\" != \"\"/ { sub(/ \];/, " -a -z \"$failed\" ];"); t=4 }
+    t == 2 && /if ! just_get \"\$from\" \"\$dest2\"; then continue 2; fi/ {
+        sub(/continue 2; fi/, "failed=y; fi"); t=3 }
+    t == 1 && /info RETRIEVING/ { print "failed=\"\""; t=2 }
+    /\"\$iters\" -lt 10/ { sub(/10/, "3"); t=1 }
     1
-    END { if (t != 4) exit 1 }
+    END { if (t != 5) exit 1 }
         ' "$tmp/functions" > "$tmp/functions.new"; then
     mv -f "$tmp/functions.new" "$tmp/functions"
 else
@@ -48,6 +45,10 @@ fi
 
 # Patch debootstrap so that is does not create devices under /dev (issue #2387).
 sed -i -e 's/^setup_devices () {$/\0 return 0/' "$tmp/functions"
+
+# Fix incorrect quoting in wgetprogress call (d45ca044136553)
+sed -i -e 's/wgetprogress "$CHECKCERTIF" "$CERTIFICATE" "$PRIVATEKEY"'\
+'/wgetprogress $CHECKCERTIF $CERTIFICATE $PRIVATEKEY/' "$tmp/functions"
 
 # Patch debootstrap to use curl instead of wget
 # Note that we do not translate other parameter, and lose the progress bar, but


### PR DESCRIPTION
Fixes #3772.

(Running tests now: `2018-06-11_00-16-01_drinkcat_chroagh_debootstrap_1`)