### PR TITLE
Override arm64 ARCH on wheezy if not explicitly chosen

### DIFF
--- a/installer/debian/defaults
+++ b/installer/debian/defaults
@@ -8,6 +8,10 @@
 
 if [ -z "$ARCH" ]; then
     ARCH="`uname -m`"
+    if [ "$RELEASE" = 'wheezy' ] \
+            && [ "$ARCH" = 'arm64' -o "$ARCH" = 'aarch64' ]; then
+        ARCH='armhf'
+    fi
 fi
 
 case "$ARCH" in


### PR DESCRIPTION
Wheezy doesn't have arm64 builds, so use armhf instead.