### PR TITLE
Fix locale for Ubuntu Xenial

### DIFF
--- a/targets/core
+++ b/targets/core
@@ -113,7 +113,7 @@ fixkeyboardmode
 install --minimal sudo wget ca-certificates apt-transport-https
 
 # Generate and set default locale
-if [ ! -f '/etc/default/locale' ] && hash locale-gen 2>/dev/null; then
+if ! grep "LANG=" /etc/default/locale && hash locale-gen 2>/dev/null; then
     echo 'LANG=en_US.UTF-8' > '/etc/default/locale'
     locale-gen --lang en_US.UTF-8
     if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then

--- a/targets/core
+++ b/targets/core
@@ -113,7 +113,7 @@ fixkeyboardmode
 install --minimal sudo wget ca-certificates apt-transport-https
 
 # Generate and set default locale
-if ! grep "LANG=" /etc/default/locale && hash locale-gen 2>/dev/null; then
+if ! grep -q '^[^#]*LANG=' /etc/default/locale 2>/dev/null && hash locale-gen 2>/dev/null; then
     echo 'LANG=en_US.UTF-8' > '/etc/default/locale'
     locale-gen --lang en_US.UTF-8
     if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then


### PR DESCRIPTION
Previously, core checked for the absence of /etc/default/locale to
determine if a locale needed to be generated an set as the default.
Unfortunately, in Xenial /etc/default/locale exists by default in
a clean installation with a comment that reads:

    # File generated by update-locale

This commit enhances the test for /etc/default/locale to check that
the file contains `LANG=`, ensuring that a default locale is set.

Fixes: #2921 and #3283