### PR TITLE
Always show the logout menu in gnome

### DIFF
--- a/targets/gnome
+++ b/targets/gnome
@@ -15,10 +15,32 @@ else
 fi
 
 ### Append to prepare.sh:
-install --minimal evolution-data-server gnome-control-center \
-        gnome-screensaver gnome-session $legacy_session_package \
-        gnome-shell gnome-themes-standard gvfs-backends nautilus \
-        unzip gtk2-engines-pixbuf pulseaudio
+install --minimal \
+  $legacy_session_package \
+  dconf-tools \
+  evolution-data-server \
+  gnome-control-center \
+  gnome-screensaver \
+  gnome-session \
+  gnome-shell \
+  gnome-themes-standard \
+  gtk2-engines-pixbuf \
+  gvfs-backends \
+  nautilus \
+  pulseaudio \
+  unzip
+
+mkdir -p /etc/dconf/profile
+mkdir -p /etc/dconf/db/local.d
+cat << EOF > /etc/dconf/profile/user
+user-db:user
+system-db:local
+EOF
+cat << EOF > /etc/dconf/db/local.d/01-always_show_logout
+[org/gnome/shell]
+always-show-log-out=true
+EOF
+dconf update
 
 TIPS="$TIPS
 You can start GNOME via the startgnome host command: sudo startgnome


### PR DESCRIPTION
Gnome by default does not display the user section which contains the
logout option in the system menu when there is only one user. This is
a problem because there is normally only one user in a crouton chroot,
and there is no other way for the user to exit the chroot from the UI
(though it can be done using the CLI.) In this commit I install
dconf-tools and specifies a new system wide default to always show the
logout option.

I also incidentally separated the gnome packages in new lines and
alphabetized them for readability.

Fixes: #3243