### PR TITLE
Switch to using i3-wm package

### DIFF
--- a/targets/xiwi
+++ b/targets/xiwi
@@ -29,7 +29,7 @@ if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
 fi
 
 install xorg xserver-xorg-video-dummy$ltspackages
-install --minimal i3
+install --minimal i3-wm
 
 # Remove some unsupported options on old versions of i3
 if release -le precise; then


### PR DESCRIPTION
Fix #4020 

It was doing a minimal install anyway, and it
seems that this was causing issues for some users,
so just move to the base window manager.