### PR TITLE
Add ARC Sdcard support + Changed how Alsaconf handles missing configuration directory.

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -361,6 +361,11 @@ for m in /lib/modules/*; do
     fi
 done
 
+if grep -q "^arc$" "$CHROOTS/$NAME/.crouton-targets" 2>/dev/null; then #If we have the ARC target installed, bindmount the virtual SDCard.
+    bindmount /run/arc/sdcard/write/emulated/0 /var/host/sdcard/write
+    bindmount /run/arc/sdcard/read/emulated/0  /var/host/sdcard/read
+fi
+
 # Add a shm symlink to our new /var/run
 ln -sfT /dev/shm "`fixabslinks '/var/run'`/shm"
 

--- a/targets/arc
+++ b/targets/arc
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+# Copyright (c) 2016 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+REQUIRES=''
+DESCRIPTION='Enable access to the Virtual SDcard used in ARC (App Runtime for Chrome.) Will only work if Google Play is enabled and /run/arc/sdcard/ exists.'
+. "${TARGETSDIR:="$PWD"}/common"
+if [ ! -d "/run/arc/sdcard/" ]; then
+    error 99 "Error: /run/arc/sdcard does not exist! Aborting install..."
+fi
+### Append to prepare.sh:
+#Make an SDcard directory. Lets assume host exists and create the directory directly.
+echo "Creating directories..."
+mkdir -p /var/host/sdcard/write
+mkdir -p /var/host/sdcard/read
+#Add the arc group to the chroot. This does a cheaky bypass to allow the user access to the SDCard by matching the GID (Thank you Linux Security.)
+echo "Creating arc-group."
+groupadd -g 665357 arc-group
+
+TIPS="$TIPS
+ARC Virtual SDCard: You can access your 'Play Files' from /var/host/sdcard/
+"

--- a/targets/audio
+++ b/targets/audio
@@ -202,9 +202,14 @@ if [ ! -d "$alsaconf" ]; then
     alsaconf='/usr/share/alsa/alsa.conf.d'
     if [ ! -d "$alsaconf" ]; then
         echo "Unable to find correct ALSA configuration directory." >&2
-        alsaconf='/tmp'
+	echo "This might be your first time installing. So we will create the directory for you."
+	echo "Default is /usr/share/alsa/alsa.conf.d + Symlink from /etc/alsa/conf.d to said default, but feel free to move it as needed."
+        mkdir -p /usr/share/alsa/alsa.conf.d
+        mkdir -p /etc/alsa/conf.d
+        ln -s /usr/share/alsa/alsa.conf.d/10-cras.conf /etc/alsa/conf.d/10-cras.conf # Create non-existant shortcut for now.
     fi
 fi
+
 cat > "$alsaconf/10-cras.conf" <<EOF
 pcm.cras {
     type cras

--- a/targets/post-common
+++ b/targets/post-common
@@ -35,7 +35,11 @@ if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
 fi
 
 # Add the primary user
-groups='audio,input,video,wayland,sudo,plugdev,crouton'
+if ! grep -q "arc" "/.crouton-targets" > /dev/null 2>&1; then
+  groups='audio,input,video,wayland,sudo,plugdev,crouton'
+else
+  groups='audio,input,video,wayland,sudo,plugdev,crouton,arc-group'
+fi
 if ! grep -q ':1000:' /etc/passwd; then
     while ! echo "$username" | grep -q '^[a-z][-a-z0-9_]*$'; do
         if [ -n "$username" ]; then


### PR DESCRIPTION
+ Added new target "arc" + Modified enter-chroot and post-common to integrate this new target.
This target enables support for accessing the virtual sdcard used by the App Run-time for Chrome. By default, most of the files that the files apps interacts with is stored in here.

+ Changed how alsaconf deals with "non-existing" directories
Due to a bug that i can not determine the origin of, ALSA may drop the 10-cras.conf file into /tmp as a incorrectly triggered fail-safe.
A through analysis shows the following:
  - The directories are present, but the installer logic fails to detect it on the first run of that chroot's setup process.
  - Additionally, while /etc/alsa/conf.d is always first to be checked, the actual format is that all conf files are symlinked to their respective counterparts
    in /usr/share/alsa/alsa.conf.d
I have made the following change in accordance:
  - I have changed the default action for no directories found. Instead of changing the alsaconf var to /tmp, the directories are forcefully made and the default
    structure is installed. However, if the checks pass (Most likely due to the chroot being updated, which means the directories already exist), then the previous
    functionality is unaltered.

Additional post-commit notes:
Apologies for the terrible spelling in my original commit message. As it turns out, working on a Chromebook with the android apps is a bit wonky. And apparently CTRL + C and CTRL + V does not work. So hooray for that. At least the code works, so there is that.
Anyway, with that out of the way, does anyone know why the installer is bugging out around the alsaconf bit? As I referenced in my commit, I could not determine what was causing the problem of the installer not detecting the ALSA configuration directory. Maybe someone with more knowledge of bash might know, cause I don't.