### PR TITLE
Poke the new usage stat file

### DIFF
--- a/host-bin/mount-chroot
+++ b/host-bin/mount-chroot
@@ -140,6 +140,11 @@ for NAME in "$@"; do
     chown root:root "$ROOT"
     chmod 700 "$ROOT"
 
+    # Extraordinarily vague usage stat; see https://crbug.com/989219
+    if [ -z "${CROUTON_DISABLE_STATS-}" ]; then
+        touch '/run/metrics/external/crouton/crouton-started' || true
+    fi
+
     if [ -n "$PRINT" ]; then
         echo "$CHROOT"
     fi


### PR DESCRIPTION
This helps give the ChromeOS team a vague view of the approximate number of active crouton machines (who have opted into ChromeOS stats reporting).  This single-bit stat is not associated with users, machines, or the actual usage of crouton.  If this terrifies you, you can block the stat by setting CROUTON_DISABLE_STATS in your environment (the variable is plural but there are no other stats).

https://crbug.com/989219 for reference