### PR TITLE
convert_automake: Advance our function by handling negative tests

### DIFF
--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -231,7 +231,8 @@ convert_automake() {
         s/\([^ ]*\) *+= */\1=${\1}\ /
         s/ /\\ /g
         y/()/{}/
-        s/if\\ \(.*\)/if [ -n "${\1}" ]; then/
+        s/if\\ !\(.*\)/if [ -z "${\1}" ]; then/
+        s/if\\ \([^!].*\)/if [ -n "${\1}" ]; then/
         s/endif/fi/
     ' 'Makefile.am'
     echo '


### PR DESCRIPTION
We survived 5(?) years without handling negative tests in Automake,
until @dgreid came along in 522b37417 https://crrev.com/c/1968111 to
break it.

Let's handle those with another beautiful sed expression.

Fixes #4199.