### PR TITLE
Add "MyFiles" mapping to enter-chroot

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -412,6 +412,7 @@ elif [ ! -f "$shares" ]; then
 # subdirectories of those mounts.
 # The only directories that can be mapped from outside of the chroot are
 # subdirectories of the following locations:
+#  myfiles: ~/MyFiles
 #  downloads: ~/Downloads
 #  shared: /mnt/stateful_partition/crouton/shared
 #  encrypted: ~/crouton/shared
@@ -434,10 +435,16 @@ elif [ ! -f "$shares" ]; then
 
 # Share the downloads folder of the current user's profile
 downloads ~/Downloads
+# Share the "My Files" folder of the current user's profile
+myfiles ~/MyFiles
 EOF
 fi
 # Bind-mount the stuff in $CHROOT/etc/crouton/shares, unless NOLOGIN is set
 if [ -z "$NOLOGIN" -a -f "$shares" ]; then
+    localmyfiles='/home/chronos/user/MyFiles'
+    if [ ! -d "$localmyfiles" ]; then
+        localmyfiles=''
+    fi
     localdownloads='/home/chronos/user/Downloads'
     if [ ! -d "$localdownloads" ]; then
         localdownloads=''
@@ -493,6 +500,12 @@ if [ -z "$NOLOGIN" -a -f "$shares" ]; then
         line="\n  \"$src\" \"$dest\" $opts"
         # Expand src
         case "${src%%/*}" in
+            myfile|myfiles)
+                if [ -z "$localmyfiles" ]; then
+                    echo "Not mounting share (no Chromium OS user):$line" 1>&2
+                    continue
+                fi
+                src="$localmyfiles/${src#*/}";;
             download|downloads)
                 if [ -z "$localdownloads" ]; then
                     echo "Not mounting share (no Chromium OS user):$line" 1>&2

--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -435,8 +435,6 @@ elif [ ! -f "$shares" ]; then
 
 # Share the downloads folder of the current user's profile
 downloads ~/Downloads
-# Share the "My Files" folder of the current user's profile
-myfiles ~/MyFiles
 EOF
 fi
 # Bind-mount the stuff in $CHROOT/etc/crouton/shares, unless NOLOGIN is set


### PR DESCRIPTION
This commit adds a mapping to the "MyFiles" directory from the host user's home directory, and includes it by default in the chroot's `/etc/crouton/shares` file.

Adapted from https://github.com/dnschneid/crouton/issues/4051#issuecomment-602163403 by @levinit