### PR TITLE
Re-apply workaround for CRAS compilation error (issue #3352)

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -172,8 +172,10 @@ END
         {
             convert_automake
 
+            # Note: -Wno-int-in-bool-context is necessary for building CRAS on
+            # older ChromeOS versions (issue #3352).
             echo '
-                CFLAGS="$CFLAGS -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\""
+                CFLAGS="$CFLAGS -Wno-int-in-bool-context -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\""
 
                 buildlib libcras
 


### PR DESCRIPTION
Fixes #3352

This commit re-applies the workaround added in commit d11419c78e0b0c97f81f94acd8bbd6a8585b47b7, which was subsequently reverted in commit d3c1801c54260c17de7fdec8dec62d32739c4931.