### PR TITLE
Pre-populate /etc/machine-id to work around systemd install error on certain kernels (issue #4016)

### DIFF
--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -234,6 +234,9 @@ if [ -r /debootstrap ]; then
         | sed -e 's=//= =g;s/^\(\(.*\) (deleted)\)$/\1\n\2/' \
         | sort -r | xargs --no-run-if-empty -d '
 ' -n 1 umount || true
+    # Workaround for some kernel versions where debootstrap second stage
+    # crashes when attempting to generate /etc/machine-id (issue #4016).
+    date -Ins | md5sum | cut -f1 -d' ' > /etc/machine-id
     # Start the bootstrap
     /debootstrap/debootstrap --second-stage
     # Clean contents of /var/run (since we'll always be mounting over it).


### PR DESCRIPTION
Fixes #4016 

In this PR, we add a step in the prepare script to generate  `/etc/machine-id` before the systemd package is configured as part of `debootstrap --second-stage`. This basically makes `systemd-machine-id-setup` a no-op when it is invoked as part of systemd's postinst script, thus avoiding the problem in issue #4016 and #3914 .