### PR TITLE
Add a new target `somm` to address #4363

### DIFF
--- a/chroot-bin/runsommelier
+++ b/chroot-bin/runsommelier
@@ -17,6 +17,7 @@ if [ -z "$SOMM" ]; then
        --data-driver=noop --display=$WAYLAND_DISPLAY \
        --xwayland-path=/usr/bin/Xwayland \
        --accelerators=$SOMMELIER_ACCELERATORS \
+       --xwayland-gl-driver-path=/usr/lib/x86_64-linux-gnu/dri/ \
        --no-exit-with-child \
        /bin/sh -c "/usr/local/etc/sommelierrc" > /tmp/sommelier.log 2>&1 &
     sleep 3

--- a/chroot-bin/runsommelier
+++ b/chroot-bin/runsommelier
@@ -1,0 +1,37 @@
+#!/bin/sh
+GDK_BACKEND=x11
+CLUTTER_BACKEND=wayland
+XDG_RUNTIME_DIR=/var/run/chrome
+WAYLAND_DISPLAY=wayland-0
+DISPLAY=:0
+SCALE=1
+export GDK_BACKEND CLUTTER_BACKEND XDG_RUNTIME_DIR WAYLAND_DISPLAY DISPLAY SCALE
+
+SOMMELIER_ACCELERATORS="Super_L,<Control>space,<Alt>space,<Alt>bracketleft,<Alt>bracketright,<Alt>minus,<Alt>equal"
+
+SOMM=$(pidof sommelier 2> /dev/null)
+if [ -z "$SOMM" ]; then
+    sommelier -X --x-display=$DISPLAY --scale=$SCALE \
+       --glamor --drm-device=/dev/dri/renderD128  \
+       --virtwl-device=/dev/null --shm-driver=noop \
+       --data-driver=noop --display=$WAYLAND_DISPLAY \
+       --xwayland-path=/usr/bin/Xwayland \
+       --accelerators=$SOMMELIER_ACCELERATORS \
+       --no-exit-with-child \
+       /bin/sh -c "/usr/local/etc/sommelierrc" > /tmp/sommelier.log 2>&1 &
+    sleep 3
+fi
+
+SOMM=$(pidof sommelier 2> /dev/null)
+if [ ! -z "$SOMM" ]; then
+  echo "sommelier process $SOMM is running"
+else
+  echo "sommelier failed to start"
+  exit 1
+fi
+
+if [ "$1" ]; then
+    exec "$@" >> /tmp/sommelier.log 2>&1
+fi
+
+exit 0

--- a/chroot-bin/runsommelier
+++ b/chroot-bin/runsommelier
@@ -9,6 +9,9 @@ export GDK_BACKEND CLUTTER_BACKEND XDG_RUNTIME_DIR WAYLAND_DISPLAY DISPLAY SCALE
 
 SOMMELIER_ACCELERATORS="Super_L,<Control>space,<Alt>space,<Alt>bracketleft,<Alt>bracketright,<Alt>minus,<Alt>equal"
 
+# Find the architecture specific libgl1-mesa-dri library location
+GL_DRIVER_PATH=$(grep '\/dri$' "/var/lib/dpkg/info/libgl1-mesa-dri*list" | head -1 )
+
 SOMM=$(pidof sommelier 2> /dev/null)
 if [ -z "$SOMM" ]; then
     sommelier -X --x-display=$DISPLAY --scale=$SCALE \
@@ -17,7 +20,7 @@ if [ -z "$SOMM" ]; then
        --data-driver=noop --display=$WAYLAND_DISPLAY \
        --xwayland-path=/usr/bin/Xwayland \
        --accelerators=$SOMMELIER_ACCELERATORS \
-       --xwayland-gl-driver-path=/usr/lib/x86_64-linux-gnu/dri/ \
+       --xwayland-gl-driver-path=$GL_DRIVER_PATH \
        --no-exit-with-child \
        /bin/sh -c "/usr/local/etc/sommelierrc" > /tmp/sommelier.log 2>&1 &
     sleep 3

--- a/chroot-etc/sommelierrc
+++ b/chroot-etc/sommelierrc
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+if which xsetroot > /dev/null 2>&1; then
+  xsetroot -cursor_name left_ptr
+fi
+
+if [ -f ~/.xwlrc ]; then
+  . ~/.xwlrc
+fi
+
+exit 0

--- a/host-bin/startsommelier
+++ b/host-bin/startsommelier
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+# Copyright (c) 2020 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+APPLICATION="${0##*/}"
+ENTERCHROOT="$(dirname "$(readlink -f -- "$0")")/enter-chroot"
+OPTS_ENTER=''
+OPTS_SOMM=''
+
+USAGE="$APPLICATION [options] chroot_app [parameters]
+
+Wraps enter-chroot to launch a window in Chromium OS for any graphical application.
+Applications launched in this way show as independent windows.
+
+By default, it will use the primary user on the first sommelier-enabled chroot found and launch
+the chroot_app in a window.
+
+Options:
+$("$ENTERCHROOT" -h 2>&1 | grep -e ' -[bckntu]')
+
+You should be able to use normal keys inside the application. To use
+ChromeOS keys you may need to hit Search first.
+"
+
+while getopts 'bc:k:n:t:u:FTf' OPT; do
+    case "$OPT" in
+      b) OPTS_ENTER="$OPTS_ENTER -$OPT";;
+      c|k|n|t|u)
+         OPTARG="$(echo -n "$OPTARG" | sed -e "s/'/'\\\\\\''/g")"
+         OPTS_ENTER="$OPTS_ENTER -$OPT '$OPTARG'";;
+      f) OPTS_SOMM="$OPTS_SOMM -$OPT";;
+      \?) echo "$USAGE" 1>&2
+          exit 2;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ "$#" = "0" ]; then 
+    echo "$USAGE" 1>&2
+    exit 2
+fi
+
+eval "exec sh -e \"\$ENTERCHROOT\" $OPTS_ENTER \
+    exec runsommelier \"\$@\""
+    

--- a/targets/somm
+++ b/targets/somm
@@ -2,7 +2,9 @@
 # Copyright (c) 2016 The crouton Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-DESCRIPTION='Wayland backend running unaccelerated(?) in a Chromium OS window.'
+REQUIRES='core'
+PROVIDES='x11'
+DESCRIPTION='Wayland backend running in a Chromium OS window.'
 HOSTBIN='startsommelier'
 CHROOTBIN='runsommelier'
 CHROOTETC='sommelierrc'

--- a/targets/somm
+++ b/targets/somm
@@ -14,10 +14,10 @@ CHROOTETC='sommelierrc'
 XMETHOD="${XMETHOD:-sommelier}"
 
 # Download the latest sommelier
-urlbase="https://chromium.googlesource.com/chromiumos/platform2/+archive/HEAD/vm_tools"
+urlbase="https://chromium.googlesource.com/chromiumos/platform2/+archive/fef7f012df0e5ec865f94255c10503ec24d9a370/vm_tools"
 
 # Download the corresponding virtwl.h
-urlvirtwl="https://chromium.googlesource.com/chromiumos/third_party/kernel/+/refs/heads/master/include/uapi/linux/virtwl.h?format=TEXT" 
+urlvirtwl="https://chromium.googlesource.com/chromiumos/third_party/kernel/+/7f7629cc680bf3c22d547fb5333e521af58c6c9e/include/uapi/linux/virtwl.h?format=TEXT" 
 
 DUMMYBUILDTMP="`mktemp -d crouton-cras.XXXXXX --tmpdir=/tmp`"
 

--- a/targets/sommelier
+++ b/targets/sommelier
@@ -1,0 +1,67 @@
+#!/bin/sh -e -v -x
+# Copyright (c) 2016 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+DESCRIPTION='Wayland backend running unaccelerated(?) in a Chromium OS window.'
+HOSTBIN='startsommelier'
+CHROOTBIN='runsommelier'
+CHROOTETC='sommelierrc'
+. "${TARGETSDIR:="$PWD"}/common"
+
+### Append to prepare.sh:
+XMETHOD="${XMETHOD:-sommelier}"
+
+# Download the latest sommelier
+urlbase="https://chromium.googlesource.com/chromiumos/platform2/+archive/HEAD/vm_tools"
+
+# Download the corresponding virtwl.h
+urlvirtwl="https://chromium.googlesource.com/chromiumos/third_party/kernel/+/refs/heads/master/include/uapi/linux/virtwl.h?format=TEXT" 
+
+DUMMYBUILDTMP="`mktemp -d crouton-cras.XXXXXX --tmpdir=/tmp`"
+
+addtrap "rm -rf --one-file-system '$DUMMYBUILDTMP'"
+
+echo "Download sommelier..." 1>&2
+
+superinsecure=''
+if release -le wheezy; then
+     # Wheezy doesn't have the right CA in ca-certificates that validates x.org
+     superinsecure='--no-check-certificate'
+fi
+wget $superinsecure -O "$DUMMYBUILDTMP/dummy.tar.gz" \
+     "$urlbase/sommelier.tar.gz"
+
+mkdir $DUMMYBUILDTMP/linux
+wget $superinsecure -O- "$urlvirtwl" \
+    | base64 --decode> $DUMMYBUILDTMP/linux/virtwl.h
+
+install xwayland weston xorg
+
+install --minimal --asdeps pkg-config libwayland-dev libgbm-dev gcc libx11-xcb-dev libsystemd-dev libxcb-composite0-dev libxkbcommon-dev libxrender-dev libxtst-dev libpixman-1-dev ninja-build meson cmake libdrm-dev build-essential
+
+# Compilation subshell
+(
+    cd "$DUMMYBUILDTMP"
+    # -m prevents "time stamp is in the future" spam
+    tar -xzmf dummy.tar.gz
+
+    echo "Compiling sommelier..." 1>&2
+
+    meson build
+    ninja -C build
+
+    echo "Installing sommelier..." 1>&2
+
+    BINDIR="/usr/local/bin"
+    mkdir -p "$BINDIR/"
+    /usr/bin/install -s build/sommelier "$BINDIR/"
+
+) # End compilation subshell
+
+TIPS="$TIPS"'
+You can launch individual apps in ChromeOS windows by using the
+"runsommelier" command in the chroot shell. Use startsommelier to launch
+directly from the host shell.  Use the startsommelier parameter -b to
+run in the background.  Example: sudo startsommelier -b xterm
+'
+


### PR DESCRIPTION
Hope this is the right way to do things!

I created a new target `somm`.
1. Compiles and installs binary executable `/usr/local/bin/sommelier`
2. Installs a script `/usr/local/bin/runsommelier` in the chroot which sets up environment variables to run `sommelier`.
3. Installs a script `/usr/local/bin/startsommelier` in ChromeOS which is the alternative to `startxiwi`.
4. Installs `/usr/local/etc/sommelierrc` which is required by `sommelier`.

This uses `sommelier` to interact with ChromeOS Wayland compositor and start graphical programs as windows within ChromeOS without using the `crouton` extension.

As of now it works for me. The output of `glxinfo` suggests that it supports some acceleration. On the other hand the output of `vainfo` is not encouraging!

All of this is based on work done by `satmandu` over in the `chromebrew` repository.

Comments and suggestions welcome.