### PR TITLE
Wrap uname to enable glibc installs for kernel revisions >= 255

### DIFF
--- a/installer/ubuntu/prepare
+++ b/installer/ubuntu/prepare
@@ -225,6 +225,24 @@ export DEBIAN_FRONTEND=noninteractive
 echo exit 101 > /usr/sbin/policy-rc.d
 chmod +x /usr/sbin/policy-rc.d
 
+# Debian glibc won't install on kernel revisions >=255, so add a wrapper script
+# to clamp the revision number. Without also patching the uname syscalls,
+# glibc's version math will overflow, resulting in an increased minor version
+# number and possibly in glibc trying to use unavailable syscalls or features.
+if [ ! -e /bin/uname.bin -a ! -e /usr/bin/uname.bin ]; then
+    for uname in /bin/uname /usr/bin/uname; do
+        # We don't use --rename since /bin may be a temp symlink to /usr/bin.
+        # --no-rename doesn't exist on old dpkg, but --rename will become the
+        # default in the future, so we have to try both with and without.
+        dpkg-divert --divert "$uname.bin" --no-rename "$uname" 2>/dev/null \
+            || dpkg-divert --divert "$uname.bin" "$uname"
+        mv -f "$uname" "$uname.bin" 2>/dev/null || true
+    done
+    echo '#!/bin/sh -eu
+uname.bin "$@" | sed '\''s/\.\(25[5-9]\|2[6-9][0-9]\|[3-9][0-9][0-9]\)-/.254-/g'\' > /bin/uname
+    chmod +x /bin/uname
+fi
+
 # Run debootstrap second stage if it hasn't already happened
 if [ -r /debootstrap ]; then
     # Debootstrap doesn't like anything mounted under /sys or /var when it runs


### PR DESCRIPTION
Fixes #4429, although we're not yet patching uname syscalls.
The key issue is that glibc's version arithmetic can result it in
interpreting revision>=255 as minor+1, which could in turn result in
glibc trying to use kernel features that don't actually exist.
If we find that applications are crashing with SIGSYS then we'll also
need an LD_PRELOAD hack like the one here:
https://gist.github.com/dnschneid/5c88a1802868c1be74d4debb5627c8c7