### PR TITLE
systemd support with -s option

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -16,6 +16,7 @@ TARGET=''
 USERNAME='1000'
 TMPXMETHOD=''
 NOLOGIN=''
+SYSTEMD=''
 SETUPSCRIPT='/prepare.sh'
 
 USAGE="$APPLICATION [options] [command [args...]]
@@ -37,7 +38,8 @@ Options:
     -X XMETHOD  Override the auto-detected XMETHOD for this session.
     -x          Does not log in, but directly executes the command instead.
                 Note that the environment will be empty (sans TERM).
-                Specify -x a second time to run the $SETUPSCRIPT script."
+                Specify -x a second time to run the $SETUPSCRIPT script
+    -s          Start systemd inside the chroot. Requires a distribution with systemd support."                
 
 # Common functions
 . "$BINDIR/../installer/functions"
@@ -59,7 +61,7 @@ chrootcmd() {
 
 # Process arguments
 prevoptind=1
-while getopts 'bc:k:ln:t:u:X:x' f; do
+while getopts 'bc:k:ln:t:u:X:x:s' f; do
     # Disallow empty string as option argument
     if [ "$((OPTIND-prevoptind))" = 2 -a -z "$OPTARG" ]; then
         error 2 "$USAGE"
@@ -76,8 +78,9 @@ while getopts 'bc:k:ln:t:u:X:x' f; do
     X) TMPXMETHOD="$OPTARG";;
     x) NOLOGIN="$((NOLOGIN+1))"
        [ "$NOLOGIN" -gt 2 ] && NOLOGIN=2;;
-    \?) error 2 "$USAGE";;
-    esac
+    s) SYSTEMD='y';;   
+     \?) error 2 "$USAGE";;
+     esac
 done
 shift "$((OPTIND-1))"
 
@@ -348,6 +351,10 @@ fi
 bindmount /dev
 bindmount /dev/pts
 bindmount /dev/shm
+if [ -z "$SYSTEMD" ]; then
+  bindmount /tmp /tmp exec
+  bindmount /proc
+fi
 bindmount /tmp /tmp exec
 bindmount /proc
 tmpfsmount /var/run 'noexec,nosuid,mode=0755,size=10%'
@@ -656,7 +663,8 @@ fi
 ret=0
 
 # Launch the system dbus unless we are entering a basic shell.
-if [ "$NOLOGIN" != 1 ] && grep -q '^root:' "$passwd" 2>/dev/null; then
+# Launch the system dbus unless we are entering a basic shell or systemd.
+if [ ! "$NOLOGIN" = 1 ] && [ -z "$SYSTEMD" ] && grep -q '^root:' "$passwd" 2>/dev/null; then
     # Try to detect the dbus user by parsing its configuration file
     # If it fails, or if the user does not exist, `id -un '$dbususer'`
     # will fail, and we fallback on a default user name ("messagebus")
@@ -721,6 +729,21 @@ if [ -n "$NOLOGIN" ]; then
         elif [ "$ret" != 0 ]; then
             error "$ret" 'Failed to complete chroot setup.'
         fi
+    fi
+    elif [ -n "$SYSTEMD" ]; then
+    [ -e "/run/crouton/$NAME.systemd.pid" ] && \
+        read -r SYSTEMD_PID < "/run/crouton/$NAME.systemd.pid"
+    if [ -z "SYSTEMD_PID" ] || ! pwdx $SYSTEMD_PID >/dev/null 2>&1; then
+        echo "Starting systemd..."
+        env -i container=1 /sbin/minijail0 -v -C "$CHROOT" -f "/run/crouton/$NAME.systemd.pid" -i -I /bin/bash -c "exec /lib/systemd/systemd"
+        sleep 1
+        read -r SYSTEMD_PID < "/run/crouton/$NAME.systemd.pid"
+    fi
+    if [ -n "$SYSTEMD_PID" ]; then
+        echo "Entering systemd PID $SYSTEMD_PID..."
+        env -i TERM="$TERM" nsenter -m -t $SYSTEMD_PID -p -r -w -u -- su - "$USERNAME"
+    else
+        echo "Could not start systemd" >&2
     fi
 else
     # Check and run rc.local


### PR DESCRIPTION
In the chroot, systemd is not enable rendering certain things useless to the user or certain operations that cannot be done by the user. Please take this into consideration and help me to make crouton even better than you have already done so monumentally already.