### PR TITLE
Allow CRAS to compile by excluding some warnings from being treated as errors

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -175,7 +175,7 @@ END
             # Note: -Wno-int-in-bool-context is necessary for building CRAS on
             # older ChromeOS versions (issue #3352).
             echo '
-                CFLAGS="$CFLAGS -Wno-int-in-bool-context -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\" -Wno-attributes"
+                CFLAGS="$CFLAGS -Wno-int-in-bool-context -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\" -Wno-error=attributes -Wno-error=maybe-uninitialized -Wno-error=stringop-overread"
 
                 buildlib libcras
 


### PR DESCRIPTION
CRAS code triggers `attributes`, `maybe-uninitialized`, and `stringop-overread` warnings, and Crouton compiles it with `-Werror`, which turns all warnings into errors.  This excludes those specific warnings from becoming errors, and allows CRAS to compile (under sid, at least).

Fixes #4618.