### PR TITLE
Add dbus-x11 and remove dictionaries-common- from the xfce package list.

### DIFF
--- a/targets/xfce
+++ b/targets/xfce
@@ -34,8 +34,8 @@ if release -lt xenial && [ "$ARCH" = 'arm64' ]; then
     install_dummy xfce4-battery-plugin
 fi
 
-install xfce4 xfce4-goodies ubuntu=shimmer-themes, \
-        -- dictionaries-common hddtemp xorg
+install xfce4 xfce4-goodies dbus-x11 ubuntu=shimmer-themes, \
+        -- hddtemp xorg
 
 TIPS="$TIPS
 You can start Xfce via the startxfce4 host command: sudo startxfce4


### PR DESCRIPTION
dbus-x11 provides dbus-launch, without which startxfce4 just throws an error.

dictionaries-common appears to be required by xfce4 on sid now, so
excluding it was preventing xfce4 from installing.

Fixes #4395, #4396, #4399.