### PR TITLE
Use -Wno-error instead of specifying individual warnings.

### DIFF
--- a/targets/audio
+++ b/targets/audio
@@ -175,7 +175,7 @@ END
             # Note: -Wno-int-in-bool-context is necessary for building CRAS on
             # older ChromeOS versions (issue #3352).
             echo '
-                CFLAGS="$CFLAGS -Wno-int-in-bool-context -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\" -Wno-error=attributes -Wno-error=maybe-uninitialized -Wno-error=stringop-overread"
+                CFLAGS="$CFLAGS -Wno-int-in-bool-context -DCRAS_SOCKET_FILE_DIR=\"/var/run/cras\" -Wno-error"
 
                 buildlib libcras
 


### PR DESCRIPTION
The `stringop-overread` warning was added relatively recently, and specifying it individually in #4658 was preventing CRAS from building on focal.

This allows CRAS to build on sid, focal, kali-rolling, and impish.

Fixes #4659.