### PR TITLE
Remove outdated package

### DIFF
--- a/targets/kde
+++ b/targets/kde
@@ -9,7 +9,7 @@ CHROOTBIN='crouton-noroot startkde'
 . "${TARGETSDIR:="$PWD"}/common"
 
 ### Append to prepare.sh:
-install --minimal kde-baseapps kde-runtime plasma-desktop pulseaudio \
+install --minimal kde-baseapps plasma-desktop pulseaudio \
         -- network-manager
 
 if release -lt xenial -lt kali -lt stretch; then


### PR DESCRIPTION
The kde-runtime package no longer exists on newer verisons (I tested it on debian 11, not sure about the others). This pr updates the kde install so it doesn't break anymore.