### PR TITLE
Update prepare.sh to resolve gcc error during CRAS compile

### DIFF
--- a/installer/prepare.sh
+++ b/installer/prepare.sh
@@ -223,6 +223,11 @@ convert_automake() {
         # Concatenate lines ending in \
         : start; /\\$/{N; b start}
         s/ *\\\n[ \t]*/ /g
+        # Fix for #4932
+        s/\-Wundef\-prefix=HAVE_,CRAS_//g
+        s/-Wundef\-prefix=HAVE_,CRAS_//g
+        s/\-Werror=undef-prefix//g
+        s/-Werror=undef-prefix//g
         # Convert automake to shell
         s/^[^ ]*:/#\0/
         s/^\t/#\0/


### PR DESCRIPTION
Fix for #4923

CRAS fails to compile due to gcc error, a temporary fix was proposed via **targets/audio**  to omit the wrong commands but could not get it to work really... instead implemented the fix directly to convert_automake and it complied without issue. 