### PR TITLE
mount-chroot: Workaround kernel crash on chromeos-5.15 R126.

### DIFF
--- a/host-bin/mount-chroot
+++ b/host-bin/mount-chroot
@@ -76,9 +76,9 @@ whitelist() {
     fi
     policies="$sec/chromiumos/inode_security_policies"
     if [ -d "$policies" ]; then
-        for policy in "$policies/allow_"*; do
-            printf "$CHROOT" > "$policy"
-        done
+        # Touch allow_symlink first to avoid kernel crash on chromeos-5.15 R126.
+        printf "$CHROOT" > "$policies/allow_symlink"
+        printf "$CHROOT" > "$policies/allow_fifo"
     fi
     if [ -z "$mounted" ]; then
         umount "$sec"


### PR DESCRIPTION
There's a longstanding bug in the Chrome OS LSM [1] whereby the security policy type (symlink:0 or fifo:1) is passed as a parameter to fsnotify_add_mark_locked, which is really expecting the fsnotify object type (inode:0, vfsmount:1, sb:2).  For a long time this bug did not cause adverse behavior, but it has been recently activated by changes to fsnotify itself [2], which have now made it into the chroemos-5.10 -5.15 and kernel branches.

This bug causes the kernel to panic (page fault oops) when writing an unregistered path to any of the LSM fifo policy files [3].  However, if a path is registered with a symlink policy first, the kernel will add a fsnotify mark using the correct object type (symlink and inode are both 0 value), and the fifo policy may then be added to the existing mark without further issue.

1. https://chromium-review.googlesource.com/c/chromiumos/third_party/kernel/+/4659274
2. https://chromium.googlesource.com/chromiumos/third_party/kernel/+/ec44610fe2b86daef70f3f53f47d2a2542d7094f
3. /sys/kernel/security/chromiumos/inode_security_policies/*_fifo