### PR TITLE
Extension: Manifest v3

### DIFF
--- a/host-ext/crouton/background.html
+++ b/host-ext/crouton/background.html
@@ -7,7 +7,6 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title></title>
-    <script src="background.js" type="text/javascript"></script>
   </head>
   <body>
     <div><textarea id="clipboardholder" rows="2" cols="20" /></div>

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -166,40 +166,18 @@ function refreshUI() {
                 console.log("No popup listens to me.")
                 return
             }
-            chrome.runtime.sendMessage({msg: 'updateUI', data: {enabled: enabled_, debug: debug_}})
+            chrome.runtime.sendMessage({msg: 'updateUI',
+                data: {
+                    enabled: enabled_,
+                    debug: debug_,
+                    hidpi: hidpi_
+                }})
         }
     )
     for (var i = 0; i < views.length; views++) {
         var view = views[i];
         /* Make sure page is ready */
         if (view.document.readyState != "loading") {
-            /* Update hidpi mode according to checkbox state. */
-            var hidpicheck = view.document.getElementById("hidpicheck");
-            if (window.devicePixelRatio > 1) {
-                hidpicheck.onclick = function() {
-                    hidpi_ = hidpicheck.checked;
-                    /* Update local storage to persist hidpi_ setting */
-                    chrome.storage.local.set({hidpi: hidpi_});
-                    refreshUI();
-                    var disps = Object.keys(kiwi_win_);
-                    for (var i = 0; i < disps.length; i++) {
-                        var win = kiwi_win_[disps[i]];
-                        if (win.window) {
-                            if (win.isTab) {
-                                chrome.tabs.sendMessage(win.id,
-                                        {func: 'setHiDPI', param: hidpi_?1:0});
-                            } else {
-                                win.window.setHiDPI(hidpi_?1:0);
-                            }
-                        }
-                    }
-                }
-                hidpicheck.disabled = false;
-            } else {
-                hidpicheck.disabled = true;
-            }
-            hidpicheck.checked = hidpi_;
-
             /* Update status box */
             view.document.getElementById("info").textContent = status_;
 
@@ -299,6 +277,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                             {func: 'setDebug', param: debug_?1:0});
                 } else {
                     win.window.setDebug(debug_?1:0);
+                }
+            }
+        }
+    } else if (message.msg == "HiDPI") {
+        hidpi_ = message.data;
+        /* Update local storage to persist hidpi_ setting */
+        chrome.storage.local.set({hidpi: hidpi_});
+        refreshUI();
+        var disps = Object.keys(kiwi_win_);
+        for (var i = 0; i < disps.length; i++) {
+            var win = kiwi_win_[disps[i]];
+            if (win.window) {
+                if (win.isTab) {
+                    chrome.tabs.sendMessage(win.id,
+                            {func: 'setHiDPI', param: hidpi_?1:0});
+                } else {
+                    win.window.setHiDPI(hidpi_?1:0);
                 }
             }
         }

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -172,7 +172,9 @@ function refreshUI() {
                     debug: debug_,
                     hidpi: hidpi_,
                     status: status_,
-                    windows: windows_
+                    windows: windows_,
+                    showlog: showlog_,
+                    logger: logger_
                 }})
         }
     )
@@ -180,38 +182,7 @@ function refreshUI() {
         var view = views[i];
         /* Make sure page is ready */
         if (view.document.readyState != "loading") {
-            /* Update logger table */
-            var loggertable = view.document.getElementById("logger");
-
-            /* FIXME: only update needed rows */
-            while (loggertable.rows.length > 0) {
-                loggertable.deleteRow(0);
-            }
-
-            /* Only update if "show log" is enabled */
-            var logcheck = view.document.getElementById("logcheck");
-            logcheck.onclick = function() {
-                showlog_ = logcheck.checked;
-                refreshUI();
-            }
-            logcheck.checked = showlog_;
-            if (showlog_) {
-                for (var i = 0; i < logger_.length; i++) {
-                    var value = logger_[i];
-
-                    if (value[0] == LogLevel.DEBUG && !debug_)
-                        continue;
-
-                    var row = loggertable.insertRow(-1);
-                    var cell1 = row.insertCell(0);
-                    var cell2 = row.insertCell(1);
-                    var levelclass = value[0];
-                    cell1.className = "time " + levelclass;
-                    cell2.className = "value " + levelclass;
-                    cell1.innerHTML = value[1];
-                    cell2.innerHTML = value[2];
-                }
-            }
+ 
         }
     }
 }
@@ -274,6 +245,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
     } else if (message.msg == "Window") {
         websocket_.send("C" + message.data);
+    } else if (message.msg == "Logger") {
+        showlog_ = message.data;
+        refreshUI();
     }
 });
 

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -126,13 +126,15 @@ function registerKiwi(displaynum, window) {
 
 /* Close the popup window */
 function closePopup() {
-    var views = []
-    //FIXME: figure out how to replace getViews with getContexts
-    //chrome.extension.getViews({type: "popup"});
-    //chrome.runtime.getContexts({contextTypes: ['POPUP']})
-    for (var i = 0; i < views.length; views++) {
-        views[i].close();
-    }
+    chrome.runtime.getContexts({contextTypes: ['POPUP']}).then(
+        (contexts) => {
+            if (contexts.length == 0) {
+                console.log("No popup listens to me.")
+                return
+            }
+            chrome.runtime.sendMessage({msg: 'close'})
+        }
+    )
 }
 
 /* Update the icon, and refresh the popup page */
@@ -157,9 +159,6 @@ function refreshUI() {
     );
     chrome.action.setBadgeBackgroundColor({color: '#2E822B'});
 
-    var views = []
-    //FIXME: figure out how to replace getViews with getContexts
-    //chrome.extension.getViews({type: "popup"});
     chrome.runtime.getContexts({contextTypes: ['POPUP']}).then(
         (contexts) => {
             if (contexts.length == 0) {
@@ -178,13 +177,6 @@ function refreshUI() {
                 }})
         }
     )
-    for (var i = 0; i < views.length; views++) {
-        var view = views[i];
-        /* Make sure page is ready */
-        if (view.document.readyState != "loading") {
- 
-        }
-    }
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -126,7 +126,10 @@ function registerKiwi(displaynum, window) {
 
 /* Close the popup window */
 function closePopup() {
-    var views = chrome.extension.getViews({type: "popup"});
+    var views = []
+    //FIXME: figure out how to replace getViews with getContexts
+    //chrome.extension.getViews({type: "popup"});
+    //chrome.runtime.getContexts({contextTypes: ['POPUP']})
     for (var i = 0; i < views.length; views++) {
         views[i].close();
     }
@@ -154,7 +157,10 @@ function refreshUI() {
     );
     chrome.action.setBadgeBackgroundColor({color: '#2E822B'});
 
-    var views = chrome.extension.getViews({type: "popup"});
+    var views = []
+    //FIXME: figure out how to replace getViews with getContexts
+    //chrome.extension.getViews({type: "popup"});
+    //chrome.runtime.getContexts({contextTypes: ['POPUP']})
     for (var i = 0; i < views.length; views++) {
         var view = views[i];
         /* Make sure page is ready */
@@ -316,7 +322,9 @@ function clipboardStart() {
     chrome.tabs.onRemoved.addListener(
             function(id, data) { onRemoved(id, true); });
 
+    /* FIXME: create a background document
     clipboardholder_ = document.getElementById("clipboardholder");
+    */
 
     /* Notification event handlers */
     chrome.notifications.onClosed.addListener(notificationClosed);
@@ -362,16 +370,21 @@ function websocketOpen() {
 }
 
 function readClipboard() {
+    /* FIXME: create a background document
     clipboardholder_.value = "";
     clipboardholder_.select();
     document.execCommand("Paste");
     return clipboardholder_.value;
+    */
+    return "";
 }
 
 function writeClipboard(str) {
+    /* FIXME: create a background document
     clipboardholder_.value = str;
     clipboardholder_.select();
     document.execCommand("Copy");
+    */
 }
 
 /* Received a message from the server */
@@ -776,11 +789,12 @@ chrome.runtime.getPlatformInfo(function(platforminfo) {
         }
 
         /* Start the extension as soon as the background page is loaded */
+        /* FIXME: create a background document
         if (document.readyState == 'complete') {
             clipboardStart();
         } else {
             document.addEventListener('DOMContentLoaded', clipboardStart);
-        }
+        }*/
 
         chrome.runtime.onUpdateAvailable.addListener(function(details) {
             updateAvailable(details.version);

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -166,33 +166,13 @@ function refreshUI() {
                 console.log("No popup listens to me.")
                 return
             }
-            chrome.runtime.sendMessage({msg: 'updateUI', data: {enabled: enabled_}})
+            chrome.runtime.sendMessage({msg: 'updateUI', data: {enabled: enabled_, debug: debug_}})
         }
     )
     for (var i = 0; i < views.length; views++) {
         var view = views[i];
         /* Make sure page is ready */
         if (view.document.readyState != "loading") {
-            /* Update debug mode according to checkbox state. */
-            var debugcheck = view.document.getElementById("debugcheck");
-            debugcheck.onclick = function() {
-                debug_ = debugcheck.checked;
-                refreshUI();
-                var disps = Object.keys(kiwi_win_);
-                for (var i = 0; i < disps.length; i++) {
-                    var win = kiwi_win_[disps[i]];
-                    if (win.window) {
-                        if (win.isTab) {
-                            chrome.tabs.sendMessage(win.id,
-                                    {func: 'setDebug', param: debug_?1:0});
-                        } else {
-                            win.window.setDebug(debug_?1:0);
-                        }
-                    }
-                }
-            }
-            debugcheck.checked = debug_;
-
             /* Update hidpi mode according to checkbox state. */
             var hidpicheck = view.document.getElementById("hidpicheck");
             if (window.devicePixelRatio > 1) {
@@ -307,6 +287,21 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (websocket_ == null)
             websocketConnect();
         refreshUI();
+    } else if (message.msg == "Debug") {
+        debug_ = message.data;
+        refreshUI();
+        var disps = Object.keys(kiwi_win_);
+        for (var i = 0; i < disps.length; i++) {
+            var win = kiwi_win_[disps[i]];
+            if (win.window) {
+                if (win.isTab) {
+                    chrome.tabs.sendMessage(win.id,
+                            {func: 'setDebug', param: debug_?1:0});
+                } else {
+                    win.window.setDebug(debug_?1:0);
+                }
+            }
+        }
     }
 });
 

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -70,7 +70,7 @@ function setStatus(status, active) {
 }
 
 function showHelp() {
-    window.open("first.html", '_blank');
+    chrome.tabs.create({url:"first.html", active:true});
 }
 
 function updateAvailable(version) {
@@ -165,9 +165,6 @@ function refreshUI() {
         var view = views[i];
         /* Make sure page is ready */
         if (view.document.readyState != "loading") {
-            /* Update "help" link */
-            var helplink = view.document.getElementById("help");
-            helplink.onclick = showHelp;
             /* Update enable/disable link. */
             var enablelink = view.document.getElementById("enable");
             if (enabled_) {
@@ -305,6 +302,13 @@ function refreshUI() {
         }
     }
 }
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log("SERVICE rcv message " + message)
+    if (message.msg == "showHelp") {
+        showHelp();
+    }
+});
 
 /* Start the extension */
 function clipboardStart() {

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -144,15 +144,15 @@ function refreshUI() {
     else if (active_)
         icon = "connected";
 
-    chrome.browserAction.setIcon(
+    chrome.action.setIcon(
         {path: {19: icon + '-19.png', 38: icon + '-38.png'}}
     );
-    chrome.browserAction.setTitle({title: 'crouton: ' + icon});
+    chrome.action.setTitle({title: 'crouton: ' + icon});
 
-    chrome.browserAction.setBadgeText(
+    chrome.action.setBadgeText(
         {text: windows_.length > 1 ? '' + (windows_.length-1) : ''}
     );
-    chrome.browserAction.setBadgeBackgroundColor({color: '#2E822B'});
+    chrome.action.setBadgeBackgroundColor({color: '#2E822B'});
 
     var views = chrome.extension.getViews({type: "popup"});
     for (var i = 0; i < views.length; views++) {
@@ -787,9 +787,9 @@ chrome.runtime.getPlatformInfo(function(platforminfo) {
         });
     } else {
         /* Disable the icon on non-Chromium OS. */
-        chrome.browserAction.setTitle(
+        chrome.action.setTitle(
             {title: 'crouton is not available on this platform'}
         );
-        chrome.browserAction.disable();
+        chrome.action.disable();
     }
 });

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -170,7 +170,9 @@ function refreshUI() {
                 data: {
                     enabled: enabled_,
                     debug: debug_,
-                    hidpi: hidpi_
+                    hidpi: hidpi_,
+                    status: status_,
+                    windows: windows_
                 }})
         }
     )
@@ -178,33 +180,6 @@ function refreshUI() {
         var view = views[i];
         /* Make sure page is ready */
         if (view.document.readyState != "loading") {
-            /* Update status box */
-            view.document.getElementById("info").textContent = status_;
-
-            /* Update window table */
-            /* FIXME: Improve UI */
-            var windowlist = view.document.getElementById("windowlist");
-
-            while (windowlist.rows.length > 0) {
-                windowlist.deleteRow(0);
-            }
-
-            for (var i = 0; i < windows_.length; i++) {
-                var row = windowlist.insertRow(-1);
-                var cell1 = row.insertCell(0);
-                var cell2 = row.insertCell(1);
-                cell1.className = "display";
-                cell1.innerHTML = windows_[i].display;
-                cell2.className = "name";
-                cell2.innerHTML = windows_[i].name;
-                cell2.onclick = (function(i) { return function() {
-                    if (active_) {
-                        websocket_.send("C" + windows_[i].display);
-                        closePopup();
-                    }
-                } })(i);
-            }
-
             /* Update logger table */
             var loggertable = view.document.getElementById("logger");
 
@@ -297,6 +272,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 }
             }
         }
+    } else if (message.msg == "Window") {
+        websocket_.send("C" + message.data);
     }
 });
 

--- a/host-ext/crouton/background.js
+++ b/host-ext/crouton/background.js
@@ -244,7 +244,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
         }
     } else if (message.msg == "Window") {
-        websocket_.send("C" + message.data);
+        if (active_) {
+            websocket_.send("C" + message.data);
+            closePopup();
+        }
     } else if (message.msg == "Logger") {
         showlog_ = message.data;
         refreshUI();

--- a/host-ext/crouton/manifest.json
+++ b/host-ext/crouton/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": 2,
-
+  "manifest_version": 3,
   "name": "crouton integration",
   "short_name": "crouton",
   "description": "Improves integration with crouton chroots.",
@@ -9,16 +8,7 @@
     "48": "icon-48.png",
     "128": "icon-128.png"
   },
-
   "offline_enabled": true,
-  "browser_action": {
-    "default_icon": {
-        "19": "disconnected-19.png",
-        "38": "disconnected-38.png"
-    },
-    "default_popup": "popup.html",
-    "default_title": "crouton"
-  },
   "background": {
     "page": "background.html"
   },
@@ -27,5 +17,14 @@
     "clipboardWrite",
     "notifications",
     "storage"
-  ]
+  ],
+  "action": {
+    "default_icon": {
+      "19": "disconnected-19.png",
+      "38": "disconnected-38.png"
+    },
+    "default_popup": "popup.html",
+    "default_title": "crouton"
+  },
+  "content_security_policy": {}
 }

--- a/host-ext/crouton/manifest.json
+++ b/host-ext/crouton/manifest.json
@@ -3,14 +3,15 @@
   "name": "crouton integration",
   "short_name": "crouton",
   "description": "Improves integration with crouton chroots.",
-  "version": "2.5.2",
+  "version": "3.0.0",
   "icons": {
     "48": "icon-48.png",
     "128": "icon-128.png"
   },
   "offline_enabled": true,
   "background": {
-    "page": "background.html"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "permissions": [
     "clipboardRead",

--- a/host-ext/crouton/manifest.json
+++ b/host-ext/crouton/manifest.json
@@ -17,6 +17,7 @@
     "clipboardRead",
     "clipboardWrite",
     "notifications",
+    "offscreen",
     "storage"
   ],
   "action": {

--- a/host-ext/crouton/offscreen.html
+++ b/host-ext/crouton/offscreen.html
@@ -7,6 +7,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title></title>
+    <script src="offscreen.js" type="text/javascript"></script>
   </head>
   <body>
     <div><textarea id="clipboardholder" rows="2" cols="20" /></div>

--- a/host-ext/crouton/offscreen.js
+++ b/host-ext/crouton/offscreen.js
@@ -1,0 +1,28 @@
+/* Copyright (c) 2024 The crouton Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+'use strict';
+
+var clipboardholder_; /* textarea used to hold clipboard content */
+
+document.addEventListener('DOMContentLoaded', function() {
+    clipboardholder_ = document.getElementById("clipboardholder");
+
+    // Tell the service worker to start working
+    chrome.runtime.sendMessage({msg: 'offscreenReady'});
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log("CLIPBOARD rcv message " + message.msg)
+    if (message.msg == "readClipboard") {
+        clipboardholder_.value = "";
+        clipboardholder_.select();
+        document.execCommand("Paste");
+        sendResponse(clipboardholder_.value);
+    } else if (message.msg == "writeClipboard") {
+        clipboardholder_.value = message.data;
+        clipboardholder_.select();
+        document.execCommand("Copy");
+    }
+});

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -5,5 +5,7 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', function() {
-    chrome.extension.getBackgroundPage().refreshUI();
+    //FIXME: figure out how to send message to service worker
+    console.log("FIXME")
+    //chrome.extension.getBackgroundPage().refreshUI();
 });

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -5,7 +5,18 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', function() {
+    /* Update "help" link */
+    var helplink = document.getElementById("help");
+    helplink.onclick = showHelp;
     //FIXME: figure out how to send message to service worker
     console.log("FIXME")
     //chrome.extension.getBackgroundPage().refreshUI();
+});
+
+function showHelp() {
+    chrome.runtime.sendMessage({msg: 'showHelp'});
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log("POPUP rcv message " + message)
 });

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -122,5 +122,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.msg == "updateUI") {
         updateUI(message.data.enabled, message.data.debug, message.data.hidpi, message.data.status, message.data.windows,
             message.data.showlog, message.data.logger)
+    } else if (message.msg == "close") {
+        window.close()
     }
 });

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -17,7 +17,7 @@ function showHelp() {
     chrome.runtime.sendMessage({msg: 'showHelp'});
 }
 
-function updateUI(enabled, debug) {
+function updateUI(enabled, debug, hidpi) {
     if (document.readyState == "loading") {
         console.log("Document still loading")
         return
@@ -41,11 +41,22 @@ function updateUI(enabled, debug) {
         chrome.runtime.sendMessage({msg: 'Debug', data: debugcheck.checked});
     }
     debugcheck.checked = debug;
+    /* Update hidpi mode according to checkbox state. */
+    var hidpicheck = document.getElementById("hidpicheck");
+    if (window.devicePixelRatio > 1) {
+        hidpicheck.onclick = function() {
+            chrome.runtime.sendMessage({msg: 'HiDPI', data: hidpicheck.checked});
+        }
+        hidpicheck.disabled = false;
+    } else {
+        hidpicheck.disabled = true;
+    }
+    hidpicheck.checked = hidpi;
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("POPUP rcv message " + message.msg)
     if (message.msg == "updateUI") {
-        updateUI(message.data.enabled, message.data.debug)
+        updateUI(message.data.enabled, message.data.debug, message.data.hidpi)
     }
 });

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -80,11 +80,7 @@ function updateUI(enabled, debug, hidpi, status, windows, showlog, logger) {
         cell2.className = "name";
         cell2.innerHTML = windows[i].name;
         cell2.onclick = (function(i) { return function() {
-            if (active_) {
-                chrome.runtime.sendMessage({msg: 'Window', data: windows[i].display});
-                //FIXME: Figure out how to close the popup
-                //closePopup();
-            }
+            chrome.runtime.sendMessage({msg: 'Window', data: windows[i].display});
         } })(i);
     }
 

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -8,15 +8,38 @@ document.addEventListener('DOMContentLoaded', function() {
     /* Update "help" link */
     var helplink = document.getElementById("help");
     helplink.onclick = showHelp;
-    //FIXME: figure out how to send message to service worker
-    console.log("FIXME")
-    //chrome.extension.getBackgroundPage().refreshUI();
+
+    // Refresh the rest of the UI
+    chrome.runtime.sendMessage({msg: 'refreshUI'});
 });
 
 function showHelp() {
     chrome.runtime.sendMessage({msg: 'showHelp'});
 }
 
+function updateUI(enabled) {
+    if (document.readyState == "loading") {
+        console.log("Document still loading")
+        return
+    }
+    /* Update enable/disable link. */
+    var enablelink = document.getElementById("enable");
+    if (enabled) {
+        enablelink.textContent = "Disable";
+        enablelink.onclick = function() {
+            chrome.runtime.sendMessage({msg: 'Disable'});
+        }
+    } else {
+        enablelink.textContent = "Enable";
+        enablelink.onclick = function() {
+            chrome.runtime.sendMessage({msg: 'Enable'});
+        }
+    }
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    console.log("POPUP rcv message " + message)
+    console.log("POPUP rcv message " + message.msg)
+    if (message.msg == "updateUI") {
+        updateUI(message.data.enabled)
+    }
 });

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -17,7 +17,7 @@ function showHelp() {
     chrome.runtime.sendMessage({msg: 'showHelp'});
 }
 
-function updateUI(enabled, debug, hidpi) {
+function updateUI(enabled, debug, hidpi, status, windows) {
     if (document.readyState == "loading") {
         console.log("Document still loading")
         return
@@ -52,11 +52,39 @@ function updateUI(enabled, debug, hidpi) {
         hidpicheck.disabled = true;
     }
     hidpicheck.checked = hidpi;
+
+    /* Update status box */
+    document.getElementById("info").textContent = status;
+
+    /* Update window table */
+    /* FIXME: Improve UI (nah not gonna happen) */
+    var windowlist = document.getElementById("windowlist");
+
+    while (windowlist.rows.length > 0) {
+        windowlist.deleteRow(0);
+    }
+
+    for (var i = 0; i < windows.length; i++) {
+        var row = windowlist.insertRow(-1);
+        var cell1 = row.insertCell(0);
+        var cell2 = row.insertCell(1);
+        cell1.className = "display";
+        cell1.innerHTML = windows[i].display;
+        cell2.className = "name";
+        cell2.innerHTML = windows[i].name;
+        cell2.onclick = (function(i) { return function() {
+            if (active_) {
+                chrome.runtime.sendMessage({msg: 'Window', data: windows[i].display});
+                //FIXME: Figure out how to close the popup
+                //closePopup();
+            }
+        } })(i);
+    }
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("POPUP rcv message " + message.msg)
     if (message.msg == "updateUI") {
-        updateUI(message.data.enabled, message.data.debug, message.data.hidpi)
+        updateUI(message.data.enabled, message.data.debug, message.data.hidpi, message.data.status, message.data.windows)
     }
 });

--- a/host-ext/crouton/popup.js
+++ b/host-ext/crouton/popup.js
@@ -17,7 +17,7 @@ function showHelp() {
     chrome.runtime.sendMessage({msg: 'showHelp'});
 }
 
-function updateUI(enabled) {
+function updateUI(enabled, debug) {
     if (document.readyState == "loading") {
         console.log("Document still loading")
         return
@@ -35,11 +35,17 @@ function updateUI(enabled) {
             chrome.runtime.sendMessage({msg: 'Enable'});
         }
     }
+    /* Update debug mode according to checkbox state. */
+    var debugcheck = document.getElementById("debugcheck");
+    debugcheck.onclick = function() {
+        chrome.runtime.sendMessage({msg: 'Debug', data: debugcheck.checked});
+    }
+    debugcheck.checked = debug;
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("POPUP rcv message " + message.msg)
     if (message.msg == "updateUI") {
-        updateUI(message.data.enabled)
+        updateUI(message.data.enabled, message.data.debug)
     }
 });


### PR DESCRIPTION
Should fix #5035.

Manifest V3 introduces a number of changes, in particular, background pages need to be replaced by a service worker, and that service worker does not have access to the DOM of the popup page, so we need to switch everything to message passing.

Also, clipboard handling needs to done in a separate offscreen page now (with similar message passing constraints).

Only tested on a Linux laptop, with a hacked together websocket server. This needs to be tested on a Chromebook. kiwi also totally untested.